### PR TITLE
Puneet/moduleenablefix

### DIFF
--- a/x/lscosmos/keeper/handshake.go
+++ b/x/lscosmos/keeper/handshake.go
@@ -116,8 +116,11 @@ func (k Keeper) OnChanOpenAck(
 		if err := k.SetHostChainDelegationAddress(ctx, address); err != nil {
 			return err
 		}
-
 	}
+
+	// On Ack we enable module and it's transactions
+	// TODO add checks if both delegation and rewards ica exists only then enable module
+	k.SetModuleState(ctx, true)
 
 	return nil
 }

--- a/x/lscosmos/keeper/proposal.go
+++ b/x/lscosmos/keeper/proposal.go
@@ -19,7 +19,9 @@ func HandleRegisterCosmosChainProposal(ctx sdk.Context, k Keeper, content types.
 	if !oldData.IsEmpty() {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "Module was already registered")
 	}
-
+	if !content.ModuleEnabled {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "Module should also be enabled while passing register proposal")
+	}
 	if content.TokenTransferPort != ibctransfertypes.PortID {
 		return sdkerrors.Wrap(ibcporttypes.ErrInvalidPort, "Only acceptable TokenTransferPort is \"transfer\"")
 	}
@@ -61,6 +63,5 @@ func HandleRegisterCosmosChainProposal(ctx sdk.Context, k Keeper, content types.
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "Allow listed validators is invalid")
 	}
 	k.SetAllowListedValidators(ctx, content.AllowListedValidators)
-	k.SetModuleState(ctx, content.ModuleEnabled)
 	return nil
 }


### PR DESCRIPTION
## 1. Overview

Proposal may pass with register account failing. 
Which should not enable the module to do any other transactions.

## 2. Implementation details

- Disables setting of disabled module on proposal pass
- adds enable module set to happen on successful ica register account

## 3. How to test/use
- manual so far

## 4. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?

## 5. Limitations (optional)

- right now rewards account has no store, so added a todo, the setting on module account should only happen after both are successful.
