### PR TITLE
get channelid optimistically, so register-chain can pass.

### DIFF
--- a/x/lscosmos/keeper/handshake.go
+++ b/x/lscosmos/keeper/handshake.go
@@ -106,7 +106,7 @@ func (k Keeper) OnChanOpenAck(
 			DelegatorAddress: delegationAddress,
 			WithdrawAddress:  rewardAddress,
 		}
-		err := generateAndExecuteICATx(ctx, k, hostchainparams.ConnectionID, types.DelegationAccountPortID, []sdk.Msg{setWithdrawAddrMsg})
+		err := generateAndExecuteICATx(ctx, k, hostchainparams.ConnectionID, types.DelegationAccountPortID, []sdk.Msg{setWithdrawAddrMsg}, true)
 		if err != nil {
 			return err
 		}

--- a/x/lscosmos/keeper/hooks.go
+++ b/x/lscosmos/keeper/hooks.go
@@ -128,7 +128,7 @@ func (k Keeper) RewardEpochEpochWorkFlow(ctx sdk.Context, hostChainParams lscosm
 			ValidatorAddress: delegation.ValidatorAddress,
 		}
 	}
-	err := generateAndExecuteICATx(ctx, k, hostChainParams.ConnectionID, lscosmostypes.DelegationAccountPortID, withdrawRewardMsgs)
+	err := generateAndExecuteICATx(ctx, k, hostChainParams.ConnectionID, lscosmostypes.DelegationAccountPortID, withdrawRewardMsgs, false)
 	if err != nil {
 		return
 	}
@@ -195,7 +195,7 @@ func (k Keeper) OnAcknowledgementIBCTransferPacket(ctx sdk.Context, packet chann
 	}
 	msgs := DelegateMsgs(delegationState.HostChainDelegationAddress, allowlistedValidators, delegatableAmount, hostChainParams.BaseDenom)
 
-	err := generateAndExecuteICATx(ctx, k, hostChainParams.ConnectionID, lscosmostypes.DelegationAccountPortID, msgs)
+	err := generateAndExecuteICATx(ctx, k, hostChainParams.ConnectionID, lscosmostypes.DelegationAccountPortID, msgs, false)
 	if err != nil {
 		return
 	}

--- a/x/lscosmos/keeper/ica_txs.go
+++ b/x/lscosmos/keeper/ica_txs.go
@@ -11,8 +11,15 @@ import (
 	lscosmostypes "github.com/persistenceOne/pstake-native/x/lscosmos/types"
 )
 
-func generateAndExecuteICATx(ctx sdk.Context, k Keeper, connectionID string, portID string, msgs []sdk.Msg) error {
-	channelID, found := k.icaControllerKeeper.GetOpenActiveChannel(ctx, connectionID, portID)
+func generateAndExecuteICATx(ctx sdk.Context, k Keeper, connectionID string, portID string, msgs []sdk.Msg, optimistic bool) error {
+	channelID := ""
+	found := false
+	if optimistic {
+		channelID, found = k.icaControllerKeeper.GetActiveChannelID(ctx, connectionID, portID)
+
+	} else {
+		channelID, found = k.icaControllerKeeper.GetOpenActiveChannel(ctx, connectionID, portID)
+	}
 	if !found {
 		k.Logger(ctx).Error(fmt.Sprintf("failed to retrieve active channel for port %s", portID))
 		return channeltypes.ErrInvalidChannelState

--- a/x/lscosmos/types/expected_keepers.go
+++ b/x/lscosmos/types/expected_keepers.go
@@ -83,4 +83,5 @@ type ICAControllerKeeper interface {
 	GetInterchainAccountAddress(ctx sdk.Context, connectionID, portID string) (string, bool)
 	SendTx(ctx sdk.Context, chanCap *capabilitytypes.Capability, connectionID, portID string, icaPacketData icatypes.InterchainAccountPacketData, timeoutTimestamp uint64) (uint64, error)
 	GetOpenActiveChannel(ctx sdk.Context, connectionID, portID string) (string, bool)
+	GetActiveChannelID(ctx sdk.Context, connectionID, portID string) (string, bool)
 }


### PR DESCRIPTION
## 1. Overview
- sometimes register chain fails as channel state has not changed, this PR allows to fetch the channelID optimistically

## 2. Implementation details
- get active channel optimistically for setwithdraw addr

## 3. How to test/use
- manual
## 4. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?

## 5. Limitations (optional)

<!-- Describe any limitation of the capabilities listed in the Overview section. -->

## 6. Future Work (optional)

- remove if the issue is because of shorter chain params.