### PR TITLE
move remaining balance to pstake fee address.

### DIFF
--- a/x/lscosmos/keeper/hooks.go
+++ b/x/lscosmos/keeper/hooks.go
@@ -111,8 +111,16 @@ func (k Keeper) DelegationEpochWorkFlow(ctx sdk.Context, hostChainParams lscosmo
 
 	// move extra tokens to pstake address - anyone can send tokens to delegation address.
 	// should be transferred to pstake address.
-	//remainingBalance := allBalances.Sub(sdk.NewCoins(depositBalance))
+	remainingBalance := allBalances.Sub(sdk.NewCoins(depositBalance))
 
+	if !remainingBalance.Empty() {
+		feeAddr := sdk.MustAccAddressFromBech32(hostChainParams.PstakeFeeAddress)
+		err = k.bankKeeper.SendCoinsFromModuleToAccount(ctx, lscosmostypes.DepositModuleAccount, feeAddr, remainingBalance)
+		if err != nil {
+			k.Logger(ctx).Error(fmt.Sprintf("could not send remaining balance: %s in depositModuleAccount: %s with error: %s", remainingBalance, lscosmostypes.DepositModuleAccount, err))
+			return
+		}
+	}
 }
 
 func (k Keeper) RewardEpochEpochWorkFlow(ctx sdk.Context, hostChainParams lscosmostypes.HostChainParams) {


### PR DESCRIPTION
## 1. Overview

Add logic to pending todo
When ibc transfering tokens, any random tokens that are sent to the address are also sent to pstake-fee-address.

## 2. Implementation details
- remaining balance that is not ibc/atom (allbalance - ibc/atombalance) is sent to pstake-fee-addr.


## 6. Future Work (optional)

- make pstake group with 46.0, and send it to the dao, so it can decide what is to be done with such coins.