### PR TITLE
add c_value methods to mint tokens.

### DIFF
--- a/x/lscosmos/keeper/c_value.go
+++ b/x/lscosmos/keeper/c_value.go
@@ -65,19 +65,19 @@ func (k Keeper) GetCValue(ctx sdk.Context) sdk.Dec {
 	return sdk.NewDecFromInt(mintedAmount).Quo(sdk.NewDecFromInt(stakedAmount))
 }
 
-func (k Keeper) ConvertStkToToken(ctx sdk.Context, stkCoin sdk.Coin) (sdk.Coin, sdk.DecCoin) {
+func (k Keeper) ConvertStkToToken(ctx sdk.Context, stkCoin sdk.DecCoin) (sdk.Coin, sdk.DecCoin) {
 
 	// calculate the current stkToken value
-	tokenValue := stkCoin.Amount.ToDec().Mul(sdk.OneDec().Quo(k.GetCValue(ctx)))
+	tokenValue := stkCoin.Amount.Mul(sdk.OneDec().Quo(k.GetCValue(ctx)))
 
 	return sdk.NewDecCoinFromDec(k.GetIBCDenom(ctx), tokenValue).TruncateDecimal()
 }
 
-func (k Keeper) ConvertTokenToStk(ctx sdk.Context, token sdk.Coin) (sdk.Coin, sdk.DecCoin) {
+func (k Keeper) ConvertTokenToStk(ctx sdk.Context, token sdk.DecCoin) (sdk.Coin, sdk.DecCoin) {
 	mintDenom := k.GetHostChainParams(ctx).MintDenom
 
 	// calculate the current token value
-	tokenValue := token.Amount.ToDec().Mul(k.GetCValue(ctx))
+	tokenValue := token.Amount.Mul(k.GetCValue(ctx))
 
 	return sdk.NewDecCoinFromDec(mintDenom, tokenValue).TruncateDecimal()
 }

--- a/x/lscosmos/keeper/handshake.go
+++ b/x/lscosmos/keeper/handshake.go
@@ -355,8 +355,8 @@ func (k Keeper) handleAckMsgData(ctx sdk.Context, msgData *sdk.MsgData, msg sdk.
 				k.AddBalanceToDelegationState(ctx, sdk.NewCoin(hostChainParams.BaseDenom, amountOfBaseDenom))
 
 				//Mint autocompounding fee
-				pstakeFeeAmount := hostChainParams.PstakeRestakeFee.MulInt(amountOfBaseDenom).Mul(k.GetCValue(ctx))
-				protocolFee, _ := sdk.NewDecCoinFromDec(hostChainParams.MintDenom, pstakeFeeAmount).TruncateDecimal()
+				pstakeFeeAmount := hostChainParams.PstakeRestakeFee.MulInt(amountOfBaseDenom)
+				protocolFee, _ := k.ConvertTokenToStk(ctx, sdk.NewDecCoinFromDec(hostChainParams.BaseDenom, pstakeFeeAmount))
 
 				err := k.bankKeeper.MintCoins(ctx, types.ModuleName, sdk.NewCoins(protocolFee))
 				if err != nil {


### PR DESCRIPTION
## 1. Overview
- use c_value.go to mint tokens

## 2. Implementation details
- use helper methods to mint tokens rather than having that logic separated in multiple files.
- change input value of Convert functions to take sdk.DecCoin insteaad of sdk.Coin.

## 3. How to test/use
- N/a

