### PR TITLE
e2e test fix

### DIFF
--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -347,7 +347,7 @@ func (s *IntegrationTestSuite) runIBCRelayer() {
 		&dockertest.RunOptions{
 			Name:       fmt.Sprintf("%s-%s-relayer", s.chainA.id, s.chainB.id),
 			Repository: "ghcr.io/cosmos/hermes-e2e",
-			Tag:        "latest",
+			Tag:        "0.12.0",
 			NetworkID:  s.dkrNet.Network.ID,
 			Mounts: []string{
 				fmt.Sprintf("%s/:/root/hermes", hermesCfgPath),


### PR DESCRIPTION
## 1. Overview

- hermes image tag fix 
- cosmos was not tagging the e2e images earlier, they tagged it 3 days ago
- currently have fixed the version that's compatible with current e2e tests
- Will upgrade test from upstream after this