### PR TITLE
increase ICA timeout to 15mins, so it doesnt timeout during upgrades …

### DIFF
--- a/x/lscosmos/types/keys.go
+++ b/x/lscosmos/types/keys.go
@@ -80,7 +80,7 @@ const (
 	IBCTimeoutHeightIncrement uint64 = 1000
 
 	// ICATimeoutTimestamp is the ICA timeout time stamp
-	ICATimeoutTimestamp = time.Minute
+	ICATimeoutTimestamp = 15 * time.Minute
 
 	// CosmosValOperPrefix is the prefix for cosmos validator address
 	CosmosValOperPrefix = "cosmosvaloper"


### PR DESCRIPTION
…if txns pending.

ICA txn timeout also initiates channel closing.
