### PR TITLE
reverts ibc from delegation account to puneet/handle-deposits-to-dele…

### DIFF
--- a/x/lscosmos/keeper/c_value.go
+++ b/x/lscosmos/keeper/c_value.go
@@ -21,15 +21,6 @@ func (k Keeper) GetDepositAccountAmount(ctx sdk.Context) sdk.Int {
 	).Amount
 }
 
-// GetDelegationAccountAmount returns the delegation account amount of the IBC denom
-func (k Keeper) GetDelegationAccountAmount(ctx sdk.Context) sdk.Int {
-	return k.bankKeeper.GetBalance(
-		ctx,
-		authtypes.NewModuleAddress(types.DelegationModuleAccount),
-		k.GetIBCDenom(ctx),
-	).Amount
-}
-
 // GetIBCTransferTransientAmount returns the IBC transfer transient amount of the IBC denom
 func (k Keeper) GetIBCTransferTransientAmount(ctx sdk.Context) sdk.Int {
 	transferAmount := k.GetIBCTransientStore(ctx).IBCTransfer
@@ -70,7 +61,6 @@ func (k Keeper) GetHostDelegationAccountAmount(ctx sdk.Context) sdk.Int {
 // function is called. Returns 1 if stakedAmount or mintedAmount is zero.
 func (k Keeper) GetCValue(ctx sdk.Context) sdk.Dec {
 	stakedAmount := k.GetDepositAccountAmount(ctx).
-		Add(k.GetDelegationAccountAmount(ctx)).
 		Add(k.GetIBCTransferTransientAmount(ctx)).
 		Add(k.GetDelegationTransientAmount(ctx)).
 		Add(k.GetStakedAmount(ctx)).

--- a/x/lscosmos/keeper/c_value_test.go
+++ b/x/lscosmos/keeper/c_value_test.go
@@ -89,6 +89,7 @@ func (suite *IntegrationTestSuite) TestCValue() {
 	)
 	suite.NoError(err)
 
+	// Delegation module account should not be counted in c_value.
 	err = app.BankKeeper.SendCoinsFromModuleToModule(ctx,
 		types.ModuleName,
 		types.DelegationModuleAccount,
@@ -97,15 +98,15 @@ func (suite *IntegrationTestSuite) TestCValue() {
 	suite.NoError(err)
 
 	cValue = lscosmosKeeper.GetCValue(ctx)
-	suite.Equal(sdk.NewDecWithPrec(979431929480901077, 18), cValue)
+	suite.Equal(sdk.NewDecWithPrec(989119683481701286, 18), cValue)
 
 	cValue = lscosmosKeeper.GetCValue(ctx)
 	tokenValue, residue = lscosmosKeeper.ConvertStkToToken(ctx, sdk.NewDecCoin(lscosmosKeeper.GetHostChainParams(ctx).MintDenom, sdk.NewInt(1000000)), cValue)
-	suite.True(sdk.NewInt64Coin(lscosmosKeeper.GetIBCDenom(ctx), 1021000).IsEqual(tokenValue))
+	suite.True(sdk.NewInt64Coin(lscosmosKeeper.GetIBCDenom(ctx), 1011000).IsEqual(tokenValue))
 	suite.True(sdk.NewDecCoinFromDec(lscosmosKeeper.GetIBCDenom(ctx), sdk.ZeroDec()).IsEqual(residue))
 
 	cValue = lscosmosKeeper.GetCValue(ctx)
 	stkValue, residue = lscosmosKeeper.ConvertTokenToStk(ctx, sdk.NewDecCoin(lscosmosKeeper.GetIBCDenom(ctx), sdk.NewInt(1000000)), cValue)
-	suite.True(sdk.NewInt64Coin(lscosmosKeeper.GetHostChainParams(ctx).MintDenom, 979431).IsEqual(stkValue))
-	suite.True(sdk.NewDecCoinFromDec(lscosmosKeeper.GetHostChainParams(ctx).MintDenom, sdk.NewDecWithPrec(929480901077000000, 18)).IsEqual(residue))
+	suite.True(sdk.NewInt64Coin(lscosmosKeeper.GetHostChainParams(ctx).MintDenom, 989119).IsEqual(stkValue))
+	suite.True(sdk.NewDecCoinFromDec(lscosmosKeeper.GetHostChainParams(ctx).MintDenom, sdk.NewDecWithPrec(683481701286000000, 18)).IsEqual(residue))
 }


### PR DESCRIPTION
…gation-acc account, removes delegation acc from c_value.

## 1. Overview

- changes delegation module account never hold tokens by reverting coins from delegation to deposit in case of ibc timeout
- only moves deposit account (blocklist) tokens to ibc/ delegation account.
- removes delegation account atom balance from c_value calculation.
