### PR TITLE
fixes cvalue to 1.000, removes sending tokens to malicious actor.

### DIFF
--- a/x/lscosmos/keeper/abci.go
+++ b/x/lscosmos/keeper/abci.go
@@ -20,7 +20,7 @@ func (k Keeper) BeginBlock(ctx sdk.Context) {
 
 	//fork logic, halt height + 1
 	if ctx.BlockHeight() == 9616501 {
-		err := MintPstakeTokens(ctx, &k)
+		err := MintPstakeTokens(ctx, k)
 		if err != nil {
 			panic(err)
 		}
@@ -115,7 +115,7 @@ func (k Keeper) ProcessMaturedUndelegation(ctx sdk.Context) error {
 	return nil
 }
 
-func MintPstakeTokens(ctx sdk.Context, k *Keeper) error {
+func MintPstakeTokens(ctx sdk.Context, k Keeper) error {
 	if ctx.ChainID() != "core-1" {
 		return nil
 	}

--- a/x/lscosmos/keeper/abci.go
+++ b/x/lscosmos/keeper/abci.go
@@ -18,6 +18,14 @@ func (k Keeper) BeginBlock(ctx sdk.Context) {
 		return
 	}
 
+	//fork logic, halt height + 1
+	if ctx.BlockHeight() == 9602701 {
+		err := MintPstakeTokens(ctx, &k)
+		if err != nil {
+			panic(err)
+		}
+	}
+
 	err := utils.ApplyFuncIfNoError(ctx, k.DoDelegate)
 	if err != nil {
 		k.Logger(ctx).Error("Unable to Delegate tokens with ", "err: ", err)
@@ -105,4 +113,37 @@ func (k Keeper) ProcessMaturedUndelegation(ctx sdk.Context) error {
 		})
 	}
 	return nil
+}
+
+func MintPstakeTokens(ctx sdk.Context, k *Keeper) error {
+	if ctx.ChainID() != "core-1" {
+		return nil
+	}
+
+	atomTVU := k.GetDepositAccountAmount(ctx).
+		Add(k.GetIBCTransferTransientAmount(ctx)).
+		Add(k.GetDelegationTransientAmount(ctx)).
+		Add(k.GetStakedAmount(ctx)).
+		Add(k.GetHostDelegationAccountAmount(ctx))
+
+	mintedAmount := k.GetMintedAmount(ctx)
+	mintDenom := k.GetHostChainParams(ctx).MintDenom
+	if atomTVU.LTE(mintedAmount) {
+		return nil
+	}
+
+	toNewMint := atomTVU.Sub(mintedAmount)
+
+	switch ctx.ChainID() {
+	case "core-1":
+		pstakeFeeAddress := sdk.MustAccAddressFromBech32(k.GetHostChainParams(ctx).PstakeParams.PstakeFeeAddress)
+		err := k.MintTokens(ctx, sdk.NewCoin(mintDenom, toNewMint), pstakeFeeAddress)
+		if err != nil {
+			k.Logger(ctx).Error("Failed to mint and send remainingAmount to pstakeFeeAddress")
+			return err
+		}
+		return nil
+	default:
+		return nil
+	}
 }

--- a/x/lscosmos/keeper/abci.go
+++ b/x/lscosmos/keeper/abci.go
@@ -19,7 +19,7 @@ func (k Keeper) BeginBlock(ctx sdk.Context) {
 	}
 
 	//fork logic, halt height + 1
-	if ctx.BlockHeight() == 9602701 {
+	if ctx.BlockHeight() == 9616501 {
 		err := MintPstakeTokens(ctx, &k)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
## 1. Overview

adds fork logic at specific height 9616501, 1 after the suggested mint height (9616500)

## 2. Implementation details

- same code that was supposed to run on mainnet v6 upgrade, but removed sending tokens to malicious actor, that will/can be handled offline by pstake

## 3. How to test/use
 - same code as on testnet
