### PR TITLE
bind baseDenom and mintDenom.

### DIFF
--- a/x/lscosmos/client/cli/tx.go
+++ b/x/lscosmos/client/cli/tx.go
@@ -121,6 +121,9 @@ $ %s tx gov submit-proposal pstake-lscosmos-register-host-chain <path/to/proposa
 			if err != nil {
 				return err
 			}
+			if types.ConvertBaseDenomToMintDenom(proposal.BaseDenom) != proposal.MintDenom {
+				return types.ErrInvalidMintDenom
+			}
 
 			content := types.NewRegisterHostChainProposal(
 				proposal.Title,
@@ -558,6 +561,10 @@ func NewJumpStartCmd() *cobra.Command {
 				PstakeUnstakeFee:    unstakeFee,
 				PstakeRedemptionFee: redemptionFee,
 				PstakeFeeAddress:    pstakeAddress.String(),
+			}
+
+			if types.ConvertBaseDenomToMintDenom(msgDetails.BaseDenom) != msgDetails.MintDenom {
+				return types.ErrInvalidMintDenom
 			}
 
 			msg := types.NewMsgJumpStart(pstakeAddress, msgDetails.ChainID, msgDetails.ConnectionID, msgDetails.TransferChannel,

--- a/x/lscosmos/keeper/msg_server.go
+++ b/x/lscosmos/keeper/msg_server.go
@@ -403,9 +403,8 @@ func (m msgServer) JumpStart(goCtx context.Context, msg *types.MsgJumpStart) (*t
 	if err := msg.PstakeParams.Validate(); err != nil {
 		return nil, err
 	}
-	if msg.BaseDenom == msg.MintDenom {
-		//TODO enforce mintdenom => stk/basedenom it in future versions
-		return nil, types.ErrEqualBaseAndMintDenom
+	if types.ConvertBaseDenomToMintDenom(msg.BaseDenom) != msg.MintDenom {
+		return nil, types.ErrInvalidMintDenom
 	}
 	// do proposal things
 	if msg.TransferPort != ibctransfertypes.PortID {

--- a/x/lscosmos/types/errors.go
+++ b/x/lscosmos/types/errors.go
@@ -36,4 +36,5 @@ var (
 	ErrInvalidMsgs                           = sdkerrors.Register(ModuleName, 86, "Invalid Msgs")
 	ErrEqualBaseAndMintDenom                 = sdkerrors.Register(ModuleName, 87, "BaseDenom and mintDenom cannot be same")
 	ErrInsufficientFundsToUndelegate         = sdkerrors.Register(ModuleName, 88, "undelegation amount greater than already staked")
+	ErrInvalidMintDenom                      = sdkerrors.Register(ModuleName, 89, "InvalidMintDenom, MintDenom should be stk/BaseDenom")
 )

--- a/x/lscosmos/types/governance_proposal.go
+++ b/x/lscosmos/types/governance_proposal.go
@@ -92,9 +92,8 @@ func (m *RegisterHostChainProposal) ValidateBasic() error {
 		return sdkerrors.Wrapf(ErrInValidAllowListedValidators, "allow listed validators is not valid")
 	}
 
-	if m.BaseDenom == m.MintDenom {
-		//TODO enforce mintdenom => stk/basedenom it in future versions
-		return ErrEqualBaseAndMintDenom
+	if ConvertBaseDenomToMintDenom(m.BaseDenom) != m.MintDenom {
+		return ErrInvalidMintDenom
 	}
 
 	err = m.PstakeParams.Validate()

--- a/x/lscosmos/types/keys.go
+++ b/x/lscosmos/types/keys.go
@@ -81,6 +81,8 @@ const (
 
 	// CosmosValOperPrefix is the prefix for cosmos validator address
 	CosmosValOperPrefix = "cosmosvaloper"
+
+	LiquidStakedDenomPrefix = "stk"
 )
 
 // fee limits

--- a/x/lscosmos/types/lscosmos.go
+++ b/x/lscosmos/types/lscosmos.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"errors"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -212,4 +213,18 @@ func (pstakeParams *PstakeParams) Validate() error {
 		return sdkerrors.Wrapf(ErrInvalidFee, "pstake redemption fee must be between %s and %s", sdk.ZeroDec(), MaxPstakeRedemptionFee)
 	}
 	return nil
+}
+
+func ConvertMintDenomToBaseDenom(mintDenom string) (string, error) {
+	denomSplit := strings.Split(mintDenom, "/")
+
+	if denomSplit[0] != LiquidStakedDenomPrefix || len(denomSplit) != 2 {
+		return "", ErrInvalidMintDenom
+	}
+	return denomSplit[1], nil
+
+}
+
+func ConvertBaseDenomToMintDenom(baseDenom string) string {
+	return fmt.Sprintf("%s/%s", LiquidStakedDenomPrefix, baseDenom)
 }

--- a/x/lscosmos/types/msgs.go
+++ b/x/lscosmos/types/msgs.go
@@ -285,6 +285,9 @@ func (m *MsgJumpStart) ValidateBasic() error {
 	if m.MinDeposit.LTE(sdk.ZeroInt()) {
 		return sdkErrors.Wrapf(ErrInvalidDeposit, "min deposit must be positive")
 	}
+	if ConvertBaseDenomToMintDenom(m.BaseDenom) != m.MintDenom {
+		return ErrInvalidMintDenom
+	}
 	return m.HostAccounts.Validate()
 }
 


### PR DESCRIPTION
## 1. Overview

In x/lscosmos/keeper/msg_server.go:485-488, during the handling of the JumpStart message, the defined guard only checks that mint and base denoms are not equal.
By design, MintDenom should be derived from BaseDenom with the stk prefix, so the mint denom should be derived from the base denom in code.
## 2. Implementation details


We recommend enforcing that MintDenom is constructed from BaseDenom and the stk prefix.
