### PR TITLE
inconsistent state fixes

### DIFF
--- a/x/lscosmos/keeper/handshake.go
+++ b/x/lscosmos/keeper/handshake.go
@@ -292,57 +292,70 @@ func (k Keeper) handleSuccessfulAck(ctx sdk.Context, ack channeltypes.Acknowledg
 		// TODO: handle for sdk 0.46.x
 		return nil
 	default:
+		msgsCount := 0
+		expectedMsgType := txMsgData.Data[0].MsgType
 		for i, msgData := range txMsgData.Data {
 			response, err := k.handleAckMsgData(ctx, msgData, msgs[i], hostChainParams)
 			if err != nil {
 				return err
 			}
 			k.Logger(ctx).Info("message response in ICS-27 packet response", "response", response)
-
-			// if the packet has withdrawrewards msgs
-			if i == 0 && msgData.MsgType == sdk.MsgTypeURL(&distributiontypes.MsgWithdrawDelegatorReward{}) {
-				rewardAddr := k.GetHostChainRewardAddress(ctx)
-
-				balanceQuery := banktypes.QueryBalanceRequest{Address: rewardAddr.Address, Denom: hostChainParams.BaseDenom}
-				bz, err := k.cdc.Marshal(&balanceQuery)
-				if err != nil {
-					return err
-				}
-
-				// total rewards balance withdrawn
-				k.icqKeeper.MakeRequest(
-					ctx,
-					hostChainParams.ConnectionID,
-					hostChainParams.ChainID,
-					"cosmos.bank.v1beta1.Query/Balance",
-					bz,
-					sdk.NewInt(int64(-1)),
-					types.ModuleName,
-					RewardsAccountBalance,
-					0,
-				)
+			if expectedMsgType == msgData.MsgType {
+				msgsCount++
 			}
-			if i == 0 && msgData.MsgType == sdk.MsgTypeURL(&stakingtypes.MsgUndelegate{}) {
-				previousEpochNumber := types.PreviousUnbondingEpoch(k.epochKeeper.GetEpochInfo(ctx, types.UndelegationEpochIdentifier).CurrentEpoch)
-				//May be also match amount with previous epoch incase host chain is down for multiple entire epoch duration. (or add epochnumber in memo ~ not clean, or store (sequenceNumber,epoch of the ica txn) )
-				previousEpochUnbondings := k.GetUnbondingEpochCValue(ctx, previousEpochNumber)
-				err = k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.UndelegationModuleAccount, types.ModuleName, sdk.NewCoins(previousEpochUnbondings.STKBurn))
-				if err != nil {
-					return err
-				}
-				err = k.bankKeeper.BurnCoins(ctx, types.ModuleName, sdk.NewCoins(previousEpochUnbondings.STKBurn))
-				if err != nil {
-					return err
-				}
+			// assert all msgs are of same type.
+			if len(txMsgData.Data) == msgsCount {
+				switch expectedMsgType {
+				case sdk.MsgTypeURL(&distributiontypes.MsgWithdrawDelegatorReward{}):
+					rewardAddr := k.GetHostChainRewardAddress(ctx)
 
-				//update completionTime
-				var msgResponse stakingtypes.MsgUndelegateResponse
-				if err := k.cdc.Unmarshal(msgData.Data, &msgResponse); err != nil {
-					return err
+					balanceQuery := banktypes.QueryBalanceRequest{Address: rewardAddr.Address, Denom: hostChainParams.BaseDenom}
+					bz, err := k.cdc.Marshal(&balanceQuery)
+					if err != nil {
+						return err
+					}
+
+					// total rewards balance withdrawn
+					k.icqKeeper.MakeRequest(
+						ctx,
+						hostChainParams.ConnectionID,
+						hostChainParams.ChainID,
+						"cosmos.bank.v1beta1.Query/Balance",
+						bz,
+						sdk.NewInt(int64(-1)),
+						types.ModuleName,
+						RewardsAccountBalance,
+						0,
+					)
+				case sdk.MsgTypeURL(&stakingtypes.MsgUndelegate{}):
+					previousEpochNumber := types.PreviousUnbondingEpoch(k.epochKeeper.GetEpochInfo(ctx, types.UndelegationEpochIdentifier).CurrentEpoch)
+					//May be also match amount with previous epoch incase host chain is down for multiple entire epoch duration. (or add epochnumber in memo ~ not clean, or store (sequenceNumber,epoch of the ica txn) )
+					previousEpochUnbondings := k.GetUnbondingEpochCValue(ctx, previousEpochNumber)
+					err = k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.UndelegationModuleAccount, types.ModuleName, sdk.NewCoins(previousEpochUnbondings.STKBurn))
+					if err != nil {
+						return err
+					}
+					err = k.bankKeeper.BurnCoins(ctx, types.ModuleName, sdk.NewCoins(previousEpochUnbondings.STKBurn))
+					if err != nil {
+						return err
+					}
+
+					//update completionTime
+					var msgResponse stakingtypes.MsgUndelegateResponse
+					if err := k.cdc.Unmarshal(msgData.Data, &msgResponse); err != nil {
+						return err
+					}
+					k.UpdateCompletionTimeForUndelegationEpoch(ctx, previousEpochNumber, msgResponse.CompletionTime.Add(types.UndelegationCompletionTimeBuffer))
+				default:
+
 				}
-				k.UpdateCompletionTimeForUndelegationEpoch(ctx, previousEpochNumber, msgResponse.CompletionTime.Add(types.UndelegationCompletionTimeBuffer))
 			}
 		}
+		if msgsCount != len(txMsgData.Data) {
+			k.SetModuleState(ctx, false) //Disable module, we assert single type of msg throughout the tx.
+			return nil
+		}
+
 	}
 	return nil
 }

--- a/x/lscosmos/keeper/handshake.go
+++ b/x/lscosmos/keeper/handshake.go
@@ -353,6 +353,7 @@ func (k Keeper) handleSuccessfulAck(ctx sdk.Context, ack channeltypes.Acknowledg
 		}
 		if msgsCount != len(txMsgData.Data) {
 			k.SetModuleState(ctx, false) //Disable module, we assert single type of msg throughout the tx.
+			k.Logger(ctx).Error(fmt.Sprintf("%s module has been disabled due to different msg types in a ica txn", types.ModuleName))
 			return nil
 		}
 


### PR DESCRIPTION
Inconsistent state mutation when handling acknowledgments
## 1. Overview

<!-- What are you changing, removing, or adding in this review? -->
In x/lscosmos/keeper/handshake.go:298-320, the delegator’s reward withdrawal and undelegation message are only processed if they are at the first index of the txMsgData.Data slice. Only the first message is processed if multiple messages are provided when handling successful acknowledgments.
Besides that, the handleAckMsgData function in line 291 performs a mutation for undelegation messages. In line 421, SubtractHostAccountDelegation is called to deduct the host account’s delegation based on the undelegation message amount.
Suppose that a MsgWithdrawDelegatorReward and MsgUndelegate message is sent. The first loop would process the delegator’s reward withdrawal. On the second loop, handleAckMsgData would be executed to subtract the host account’s delegation amount. However, the undelegation message is not processed since it’s on the second index.
As a result, in case of receiving multiple transaction messages in the OnAcknowledgementPacket callback function, only the first message of MsgUndelegate is executed. This causes a state inconsistency issue because matured undelegations are not recorded properly, causing users unable to retrieve their unbonded ATOMs.
## 2. Implementation details
asserts that each msgs of the code has the same typeurl.
<!-- Describe the implementation (highlights only) as well as design rationale. -->

## 3. How to test/use

<!-- How can people test/use this? -->

## 4. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?

## 5. Limitations (optional)

<!-- Describe any limitation of the capabilities listed in the Overview section. -->

## 6. Future Work (optional)

<!-- Describe follow up work, if any. -->