### PR TITLE
[LiquidStakeIbc] Fixes

### DIFF
--- a/x/liquidstakeibc/keeper/hooks.go
+++ b/x/liquidstakeibc/keeper/hooks.go
@@ -143,7 +143,8 @@ func (k *Keeper) OnRecvIBCTransferPacket(
 
 	// the transfer is part of the undelegation process
 	if data.GetSender() == hc.DelegationAccount.Address &&
-		data.GetReceiver() == k.GetUndelegationModuleAccount(ctx).GetAddress().String() {
+		data.GetReceiver() == k.GetUndelegationModuleAccount(ctx).GetAddress().String() &&
+		data.Memo == "" {
 		k.Logger(ctx).Info(
 			"Received unbonding IBC transfer.",
 			"host chain",
@@ -160,8 +161,7 @@ func (k *Keeper) OnRecvIBCTransferPacket(
 		unbondings := k.FilterUnbondings(
 			ctx,
 			func(u liquidstakeibctypes.Unbonding) bool {
-				return u.State == liquidstakeibctypes.Unbonding_UNBONDING_MATURED &&
-					u.IbcSequenceId == k.GetTransactionSequenceID(packet.SourceChannel, packet.Sequence)
+				return u.ChainId == hc.ChainId && u.State == liquidstakeibctypes.Unbonding_UNBONDING_MATURED
 			},
 		)
 

--- a/x/liquidstakeibc/keeper/hooks.go
+++ b/x/liquidstakeibc/keeper/hooks.go
@@ -115,6 +115,16 @@ func (k *Keeper) OnRecvIBCTransferPacket(
 	relayer sdk.AccAddress,
 	transferAck ibcexported.Acknowledgement,
 ) error {
+	k.Logger(ctx).Info(
+		"Received incoming IBC transfer.",
+		"sequence",
+		packet.Sequence,
+		"port",
+		packet.DestinationPort,
+		"channel",
+		packet.DestinationChannel,
+	)
+
 	if !transferAck.Success() {
 		return nil
 	}
@@ -134,6 +144,18 @@ func (k *Keeper) OnRecvIBCTransferPacket(
 	// the transfer is part of the undelegation process
 	if data.GetSender() == hc.DelegationAccount.Address &&
 		data.GetReceiver() == k.GetUndelegationModuleAccount(ctx).GetAddress().String() {
+		k.Logger(ctx).Info(
+			"Received unbonding IBC transfer.",
+			"host chain",
+			hc.ChainId,
+			"sequence",
+			packet.Sequence,
+			"port",
+			packet.DestinationPort,
+			"channel",
+			packet.DestinationChannel,
+		)
+
 		// get all the unbondings for that ibc sequence id
 		unbondings := k.FilterUnbondings(
 			ctx,
@@ -155,6 +177,18 @@ func (k *Keeper) OnRecvIBCTransferPacket(
 	if data.GetSender() == hc.DelegationAccount.Address &&
 		data.GetReceiver() == k.GetDepositModuleAccount(ctx).GetAddress().String() &&
 		data.Memo == "" {
+		k.Logger(ctx).Info(
+			"Received total validator unbonding IBC transfer.",
+			"host chain",
+			hc.ChainId,
+			"sequence",
+			packet.Sequence,
+			"port",
+			packet.DestinationPort,
+			"channel",
+			packet.DestinationChannel,
+		)
+
 		// add the unbonded amount to the deposit record for that chain/epoch
 		currentEpoch := k.GetEpochNumber(ctx, liquidstakeibctypes.DelegationEpoch)
 		deposit, found := k.GetDepositForChainAndEpoch(ctx, hc.ChainId, currentEpoch)
@@ -184,6 +218,18 @@ func (k *Keeper) OnRecvIBCTransferPacket(
 	if data.GetSender() == hc.RewardsAccount.Address &&
 		data.GetReceiver() == k.GetDepositModuleAccount(ctx).GetAddress().String() &&
 		data.Memo == "" {
+		k.Logger(ctx).Info(
+			"Received autocompounding IBC transfer.",
+			"host chain",
+			hc.ChainId,
+			"sequence",
+			packet.Sequence,
+			"port",
+			packet.DestinationPort,
+			"channel",
+			packet.DestinationChannel,
+		)
+
 		// parse the transfer amount
 		transferAmount, ok := sdk.NewIntFromString(data.Amount)
 		if !ok {
@@ -271,8 +317,7 @@ func (k *Keeper) OnAcknowledgementIBCTransferPacket(
 		return fmt.Errorf("could not parse ibc transfer amount %s", data.Amount)
 	}
 
-	// if the sender is the deposit module account, mark the corresponding deposits as received and send an
-	// ICQ query to get the new host delegator account balance
+	// if the sender is the deposit module account, mark the corresponding deposits as received and update the balance
 	if data.GetSender() == authtypes.NewModuleAddress(liquidstakeibctypes.DepositModuleAccount).String() {
 		deposits := k.GetDepositsWithSequenceID(ctx, k.GetTransactionSequenceID(packet.SourceChannel, packet.Sequence))
 		for _, deposit := range deposits {
@@ -295,6 +340,18 @@ func (k *Keeper) OnAcknowledgementIBCTransferPacket(
 
 			hc.CValue = k.GetHostChainCValue(ctx, hc)
 			k.SetHostChain(ctx, hc)
+
+			k.Logger(ctx).Info(
+				"Got delegation deposit received ACK.",
+				"host chain",
+				hc.ChainId,
+				"sequence",
+				packet.Sequence,
+				"port",
+				packet.SourceChannel,
+				"channel",
+				packet.SourceChannel,
+			)
 		}
 	}
 
@@ -336,12 +393,26 @@ func (k *Keeper) OnTimeoutIBCTransferPacket(
 		k.GetDepositsWithSequenceID(ctx, k.GetTransactionSequenceID(packet.SourceChannel, packet.Sequence)),
 	)
 
+	k.Logger(ctx).Info(
+		"Deposit transfer timed out.",
+		"host chain",
+		hc.ChainId,
+		"sequence",
+		packet.Sequence,
+		"port",
+		packet.SourceChannel,
+		"channel",
+		packet.SourceChannel,
+	)
+
 	return nil
 }
 
 // Workflows
 
 func (k *Keeper) DepositWorkflow(ctx sdk.Context, epoch int64) {
+	k.Logger(ctx).Info("Running deposit workflow.", "epoch", epoch)
+
 	deposits := k.GetPendingDepositsBeforeEpoch(ctx, epoch)
 	for _, deposit := range deposits {
 		hc, found := k.GetHostChain(ctx, deposit.ChainId)
@@ -409,6 +480,8 @@ func (k *Keeper) DepositWorkflow(ctx sdk.Context, epoch int64) {
 }
 
 func (k *Keeper) UndelegationWorkflow(ctx sdk.Context, epoch int64) {
+	k.Logger(ctx).Info("Running undelegation workflow.", "epoch", epoch)
+
 	for _, hc := range k.GetAllHostChains(ctx) {
 		// don't do anything if the chain is not active
 		if !hc.Active {
@@ -478,6 +551,8 @@ func (k *Keeper) UndelegationWorkflow(ctx sdk.Context, epoch int64) {
 }
 
 func (k *Keeper) ValidatorUndelegationWorkflow(ctx sdk.Context, epoch int64) {
+	k.Logger(ctx).Info("Running validator undelegation workflow.", "epoch", epoch)
+
 	for _, hc := range k.GetAllHostChains(ctx) {
 		// don't do anything if the chain is not active
 		if !hc.Active {
@@ -550,6 +625,8 @@ func (k *Keeper) ValidatorUndelegationWorkflow(ctx sdk.Context, epoch int64) {
 }
 
 func (k *Keeper) RewardsWorkflow(ctx sdk.Context, epoch int64) {
+	k.Logger(ctx).Info("Running rewards workflow.", "epoch", epoch)
+
 	for _, hc := range k.GetAllHostChains(ctx) {
 		// don't do anything if the chain is not active
 		if !hc.Active {

--- a/x/liquidstakeibc/keeper/ibc.go
+++ b/x/liquidstakeibc/keeper/ibc.go
@@ -101,13 +101,29 @@ func (k *Keeper) OnChanOpenAck(
 	k.RevertDepositsState(ctx, k.GetDelegatingDepositsForChain(ctx, hc.ChainId))
 
 	// send an ICQ query to get the delegator account balance
-	if err := k.QueryHostChainAccountBalance(ctx, hc, hc.DelegationAccount.Address); err != nil {
-		return fmt.Errorf(
-			"error querying host chain %s for delegation account balances: %v",
-			hc.ChainId,
-			err,
-		)
+	if hc.DelegationAccount != nil {
+		if err := k.QueryHostChainAccountBalance(ctx, hc, hc.DelegationAccount.Address); err != nil {
+			return fmt.Errorf(
+				"error querying host chain %s for delegation account balances: %v",
+				hc.ChainId,
+				err,
+			)
+		}
 	}
+
+	k.Logger(ctx).Info(
+		"Created new ICA.",
+		"host chain",
+		hc.ChainId,
+		"type",
+		icaAccountType,
+		"channel",
+		channelID,
+		"owner",
+		portOwner,
+		"address",
+		address,
+	)
 
 	return nil
 }
@@ -238,6 +254,19 @@ func (k *Keeper) OnTimeoutPacket(
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
 		),
 	)
+
+	k.Logger(ctx).Info(
+		"ICA transaction timed out.",
+		"sequence",
+		packet.Sequence,
+		"channel",
+		packet.SourceChannel,
+		"port",
+		packet.SourcePort,
+		"messages",
+		messages,
+	)
+
 	return nil
 }
 
@@ -287,6 +316,16 @@ func (k *Keeper) handleUnsuccessfulAck(
 			}
 		}
 	}
+
+	k.Logger(ctx).Info(
+		"ICA transaction ACK error.",
+		"sequence",
+		sequence,
+		"channel",
+		channel,
+		"messages",
+		messages,
+	)
 
 	return nil
 }
@@ -354,6 +393,16 @@ func (k *Keeper) handleSuccessfulAck(
 			}
 		}
 	}
+
+	k.Logger(ctx).Info(
+		"ICA transaction ACK success.",
+		"sequence",
+		sequence,
+		"channel",
+		channel,
+		"messages",
+		messages,
+	)
 
 	return nil
 }

--- a/x/liquidstakeibc/keeper/ibc.go
+++ b/x/liquidstakeibc/keeper/ibc.go
@@ -83,11 +83,18 @@ func (k *Keeper) OnChanOpenAck(
 	switch icaAccountType {
 	case types.DelegateICAType:
 		hc.DelegationAccount = icaAccount
+		// register reward ICA
+		if err = k.RegisterICAAccount(ctx, hc.ConnectionId, k.RewardsAccountPortOwner(chainID)); err != nil {
+			return errorsmod.Wrapf(
+				types.ErrRegisterFailed,
+				"error registering %s reward ica: %s",
+				chainID,
+				err.Error(),
+			)
+		}
 	case types.RewardsICAType:
 		hc.RewardsAccount = icaAccount
-	}
-
-	if hc.DelegationAccount != nil && hc.RewardsAccount != nil {
+		// set host chain withdraw address
 		err := k.SetWithdrawAddress(ctx, hc)
 		if err != nil {
 			k.Logger(ctx).Error("Could not set withdraw address.", "chain_id", hc.ChainId)

--- a/x/liquidstakeibc/keeper/msg_server.go
+++ b/x/liquidstakeibc/keeper/msg_server.go
@@ -92,16 +92,6 @@ func (k msgServer) RegisterHostChain(
 		)
 	}
 
-	// register reward ICA
-	if err = k.RegisterICAAccount(ctx, hc.ConnectionId, k.RewardsAccountPortOwner(chainID)); err != nil {
-		return nil, errorsmod.Wrapf(
-			types.ErrRegisterFailed,
-			"error registering %s reward ica: %s",
-			chainID,
-			err.Error(),
-		)
-	}
-
 	// query the host chain for the validator set
 	if err := k.QueryHostChainValidators(ctx, hc, stakingtypes.QueryValidatorsRequest{}); err != nil {
 		return nil, errorsmod.Wrapf(


### PR DESCRIPTION
Add logging to IBC callbacks and hooks.

Register rewards address AFTER delegation address is registered, to avoid the case where both acks arrive at the same time, causing the withdraw address to not be set.

Stop using IBC sequence for unbonding IBC transactions as it can arrive before the ICA ACK.