### PR TITLE
update migrations.

### DIFF
--- a/x/lscosmos/types/expected_keepers.go
+++ b/x/lscosmos/types/expected_keepers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/cosmos/gogoproto/proto"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	"github.com/cosmos/ibc-go/v7/modules/core/exported"
 	ibctmtypes "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
@@ -106,4 +107,5 @@ type LiquidStakeIBCKeeper interface {
 	SetDeposit(ctx sdk.Context, deposit *liquidstakeibctypes.Deposit)
 	GetLatestConsensusState(ctx sdk.Context, connectionID string) (*ibctmtypes.ConsensusState, error)
 	GetHostChain(ctx sdk.Context, chainID string) (*liquidstakeibctypes.HostChain, bool)
+	GenerateAndExecuteICATx(ctx sdk.Context, connectionID string, ownerID string, messages []proto.Message) (string, error)
 }


### PR DESCRIPTION
fail unbondings that might be old and never created, so users can claim.