### PR TITLE
feat: add aliases for liquidstakeibc module

### DIFF
--- a/x/liquidstakeibc/client/query.go
+++ b/x/liquidstakeibc/client/query.go
@@ -19,6 +19,7 @@ import (
 func NewQueryCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        types.ModuleName,
+		Aliases:                    []string{"liquidstake", "lsibc"},
 		Short:                      "Querying commands for the pstake liquid staking ibc module",
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,

--- a/x/liquidstakeibc/client/tx.go
+++ b/x/liquidstakeibc/client/tx.go
@@ -19,6 +19,7 @@ import (
 func NewTxCmd() *cobra.Command {
 	txCmd := &cobra.Command{
 		Use:                        types.ModuleName,
+		Aliases:                    []string{"liquidstake", "lsibc"},
 		Short:                      "Pstake liquid staking ibc transaction subcommands",
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,


### PR DESCRIPTION
writing cli commands and typing `pstaked tx liquidstakeibc` is cumbersome, have shorter names for module `pstaked tx lsibc`  