### PR TITLE
chore: update upgrade names.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -971,14 +971,7 @@ func (app *PstakeApp) GetTxConfig() client.TxConfig {
 
 func (app *PstakeApp) RegisterUpgradeHandler() {
 	app.UpgradeKeeper.SetUpgradeHandler(
-		testnetUpgradeName,
-		func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-			return app.mm.RunMigrations(ctx, app.configurator, fromVM)
-		},
-	)
-
-	app.UpgradeKeeper.SetUpgradeHandler(
-		mainnetUpgradeName,
+		UpgradeName,
 		func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 			return app.mm.RunMigrations(ctx, app.configurator, fromVM)
 		},
@@ -989,16 +982,12 @@ func (app *PstakeApp) RegisterUpgradeHandler() {
 		panic(err)
 	}
 
-	if upgradeInfo.Name == mainnetUpgradeName && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+	if upgradeInfo.Name == UpgradeName && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := store.StoreUpgrades{
-			Added: []string{
-				liquidstakeibctypes.ModuleName,
-				consensusparamtypes.ModuleName,
-				crisistypes.ModuleName,
-				ibcfeetypes.ModuleName,
-			},
+			Added: []string{},
 			Deleted: []string{
-				//lscosmostypes.ModuleName, add this to next upgrade.
+				"lscosmos",
+				"lspersistence", //if present
 			},
 		}
 

--- a/app/const.go
+++ b/app/const.go
@@ -1,7 +1,6 @@
 package app
 
 const (
-	appName            = "pStake"
-	mainnetUpgradeName = "v2.2.0"
-	testnetUpgradeName = "v2.3.0"
+	appName     = "pStake"
+	UpgradeName = "v2.3.0"
 )


### PR DESCRIPTION
Since mainnet is upgrading to 2.2.3, and then to 2.3.0, we can reset the upgrades path