### PR TITLE
fix: LSM cap room bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## [v2.3.2] - 2023-09-07
+
+### Bug Fixes
+
+- [#639](https://github.com/persistenceOne/pstake-native/pull/639) LSM cap room bug.
+
 ## [v2.3.1] - 2023-09-06
 
 ### Bug Fixes

--- a/go.mod
+++ b/go.mod
@@ -183,5 +183,5 @@ replace (
 // use persistence's forks with LSM implemented
 replace (
 	github.com/cosmos/cosmos-sdk => github.com/persistenceOne/cosmos-sdk v0.47.3-lsm4
-	github.com/cosmos/ibc-go/v7 => github.com/persistenceOne/ibc-go/v7 v7.2.0-lsm2
+	github.com/cosmos/ibc-go/v7 => github.com/persistenceOne/ibc-go/v7 v7.2.0-lsm3
 )

--- a/go.sum
+++ b/go.sum
@@ -975,8 +975,8 @@ github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNc
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/persistenceOne/cosmos-sdk v0.47.3-lsm4 h1:HyoRiPw30IOFdNyhrXFOrU20fR1UKgtv7PsTBeVpsMU=
 github.com/persistenceOne/cosmos-sdk v0.47.3-lsm4/go.mod h1:4oxikyyHyEe1wlYQFMGITfW/r01wYtfj8yjwru7bSWE=
-github.com/persistenceOne/ibc-go/v7 v7.2.0-lsm2 h1:dZdIkhaOKB0YbetYmlbQmSC6b8hSPYUzOeET9CIYUDY=
-github.com/persistenceOne/ibc-go/v7 v7.2.0-lsm2/go.mod h1:PzDs4fL8PNx7OoxTbNqjxANKKNGL/1ucVt+Np68hLi4=
+github.com/persistenceOne/ibc-go/v7 v7.2.0-lsm3 h1:U4NsRXpg9VHCFVyrk1JfG+sIA3frtZIWbtNmmumjta8=
+github.com/persistenceOne/ibc-go/v7 v7.2.0-lsm3/go.mod h1:PDvFOPEd8Fz25qBmhX7KXSPX4COyGnytKweRdEP1yfA=
 github.com/persistenceOne/persistence-sdk/v2 v2.1.1 h1:fo8Og2QkjsqqhH/wiEiOSB99M2Jr0kLqirU2xhJRZfQ=
 github.com/persistenceOne/persistence-sdk/v2 v2.1.1/go.mod h1:6ufKMowypJB865CT5Gm6Gs42YCtSkX7k3ZqKzx63y+8=
 github.com/peterh/liner v1.0.1-0.20180619022028-8c1271fcf47f/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=

--- a/x/liquidstakeibc/keeper/setup_suite_test.go
+++ b/x/liquidstakeibc/keeper/setup_suite_test.go
@@ -152,7 +152,7 @@ func (suite *IntegrationTestSuite) SetupHostChainAB() {
 	lsmValidatorCap, err := sdk.NewDecFromStr("0.5")
 	suite.NoError(err)
 
-	lsmBondFactor, err := sdk.NewDecFromStr("250")
+	lsmBondFactor, err := sdk.NewDecFromStr("50")
 	suite.NoError(err)
 
 	hostChainLSParams := &types.HostChainLSParams{


### PR DESCRIPTION
## 1. Overview

This change fixes a bug that happens when a validator is tagged as `delegable` after checking the LSM caps (both validator and bond) but the room left until reaching the cap is less than the amount which is going to be staked by the `x/liquidstakeibc` module the next delegation epoch.

This causes the module to generate delegating messages without taking into account that room, and therefore potentially hitting any of the caps and starting an endless loop of delegations.

In order to fix this, after calculating the `delegable` flag when receiving an ICQ validator response (and only when that flag is `true`), the module will also _simulate_ the generated messages it would create during the next delegation epoch. Then, using the amounts on each of the messages, check if there is enough room to delegate to that validator. If affirmative, the validator keeps tagged as `delegable`, and as `non-delegable` otherwise.