### PR TITLE
refactor: add method to derive hostDenom from mintDenom and reverse.

### DIFF
--- a/x/liquidstakeibc/keeper/msg_server.go
+++ b/x/liquidstakeibc/keeper/msg_server.go
@@ -585,7 +585,7 @@ func (k msgServer) LiquidUnstake(
 	ctx := sdktypes.UnwrapSDKContext(goCtx)
 
 	// parse the chain host denom from the stk denom
-	_, hostDenom, found := strings.Cut(msg.Amount.Denom, "/")
+	hostDenom, found := types.MintDenomToHostDenom(msg.Amount.Denom)
 	if !found {
 		return nil, errorsmod.Wrapf(types.ErrInvalidHostChain,
 			"could not parse chain host denom from %s",
@@ -708,7 +708,7 @@ func (k msgServer) Redeem(
 	ctx := sdktypes.UnwrapSDKContext(goCtx)
 
 	// parse the chain host denom from the stk denom
-	_, hostDenom, found := strings.Cut(msg.Amount.Denom, "/")
+	hostDenom, found := types.MintDenomToHostDenom(msg.Amount.Denom)
 	if !found {
 		return nil, errorsmod.Wrapf(types.ErrInvalidHostChain,
 			"could not parse chain host denom from %s",

--- a/x/liquidstakeibc/types/host_chain.go
+++ b/x/liquidstakeibc/types/host_chain.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"fmt"
-
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	ibctfrtypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
@@ -13,7 +11,7 @@ func (hc *HostChain) IBCDenom() string {
 }
 
 func (hc *HostChain) MintDenom() string {
-	return fmt.Sprintf("%s/%s", LiquidStakeDenomPrefix, hc.HostDenom)
+	return HostDenomToMintDenom(hc.HostDenom)
 }
 
 func (hc *HostChain) GetValidator(operatorAddress string) (*Validator, bool) {

--- a/x/liquidstakeibc/types/liquidstakeibc.go
+++ b/x/liquidstakeibc/types/liquidstakeibc.go
@@ -14,6 +14,14 @@ func IsLiquidStakingDenom(denom string) bool {
 	return strings.HasPrefix(denom, fmt.Sprintf("%s/", LiquidStakeDenomPrefix))
 }
 
+func MintDenomToHostDenom(mintDenom string) (string, bool) {
+	return strings.CutPrefix(mintDenom, fmt.Sprintf("%s/", LiquidStakeDenomPrefix))
+}
+
+func HostDenomToMintDenom(hostDenom string) string {
+	return fmt.Sprintf("%s/%s", LiquidStakeDenomPrefix, hostDenom)
+}
+
 func IsUnbondingEpoch(factor, epochNumber int64) bool {
 	return epochNumber%factor == 0
 }


### PR DESCRIPTION
## 1. Overview

- add methods to derive mint denom from host denom and vice versa so it can be used in other modules.
