### PR TITLE
fix: fix ibc routing issues, and fix portID representation.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -512,6 +512,7 @@ func NewpStakeApp(
 	icaHostStack = ibcfee.NewIBCMiddleware(icaHostStack, app.IBCFeeKeeper)
 
 	var icaControllerStack porttypes.IBCModule = liquidStakeIBCModule
+	icaControllerStack = ratesync.NewIBCModule(*app.RatesyncKeeper, icaHostStack)
 	icaControllerStack = icacontroller.NewIBCMiddleware(icaControllerStack, app.ICAControllerKeeper)
 
 	ibcRouter := porttypes.NewRouter()
@@ -519,7 +520,8 @@ func NewpStakeApp(
 		AddRoute(ibctransfertypes.ModuleName, transferStack).
 		AddRoute(icahosttypes.SubModuleName, icaHostStack).
 		AddRoute(icacontrollertypes.SubModuleName, icaControllerStack).
-		AddRoute(liquidstakeibctypes.ModuleName, icaControllerStack)
+		AddRoute(liquidstakeibctypes.ModuleName, icaControllerStack).
+		AddRoute(ratesynctypes.ModuleName, icaControllerStack)
 
 	app.IBCKeeper.SetRouter(ibcRouter)
 

--- a/x/liquidstakeibc/keeper/ibc.go
+++ b/x/liquidstakeibc/keeper/ibc.go
@@ -76,7 +76,7 @@ func (k *Keeper) OnChanOpenAck(
 		hc.RewardsAccount.Owner = portOwner
 		hc.RewardsAccount.ChannelState = types.ICAAccount_ICA_CHANNEL_CREATED
 	default:
-		k.Logger(ctx).Error("Unrecognised ICA account type for the module", "port-id:", portID, "chain-id", chainID)
+		k.Logger(ctx).Info("Unrecognised ICA account type for the module", "port-id:", portID, "chain-id", chainID)
 		return nil
 	}
 

--- a/x/ratesync/keeper/abci.go
+++ b/x/ratesync/keeper/abci.go
@@ -31,7 +31,7 @@ func (k *Keeper) DoRecreateICA(ctx sdk.Context, hc types.HostChain) {
 	}
 
 	// if the channel is closed, and it is not being recreated, recreate it
-	portID := types.MustICAPortIDfromOwner(hc.IcaAccount.Owner)
+	portID := types.MustICAPortIDFromOwner(hc.IcaAccount.Owner)
 	_, isActive := k.icaControllerKeeper.GetOpenActiveChannel(ctx, hc.ConnectionId, portID)
 	if !isActive {
 		if err := k.icaControllerKeeper.RegisterInterchainAccount(ctx, hc.ConnectionId, portID, ""); err != nil {

--- a/x/ratesync/types/genesis_test.go
+++ b/x/ratesync/types/genesis_test.go
@@ -21,7 +21,7 @@ func TestGenesisState_Validate(t *testing.T) {
 		{
 			desc: "valid genesis state",
 			genState: &types.GenesisState{
-
+				Params: types.DefaultParams(),
 				HostChains: []types.HostChain{
 					{
 						Id: 0,
@@ -37,6 +37,7 @@ func TestGenesisState_Validate(t *testing.T) {
 		{
 			desc: "duplicated chain",
 			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
 				HostChains: []types.HostChain{
 					{
 						Id: 0,

--- a/x/ratesync/types/msgs.go
+++ b/x/ratesync/types/msgs.go
@@ -4,6 +4,7 @@ import (
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 )
 
 const TypeMsgUpdateParams = "msg_update_params"
@@ -98,7 +99,12 @@ func (msg *MsgCreateHostChain) ValidateBasic() error {
 	if msg.HostChain.Id != 0 {
 		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "hostchain ID for create msg should be 0")
 	}
-
+	if msg.HostChain.IcaAccount.Owner != "" {
+		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "owner should not be specified as app uses default")
+	}
+	if msg.HostChain.IcaAccount.ChannelState != liquidstakeibctypes.ICAAccount_ICA_CHANNEL_CREATING {
+		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "channel state should be creating")
+	}
 	return nil
 }
 

--- a/x/ratesync/types/msgs_test.go
+++ b/x/ratesync/types/msgs_test.go
@@ -1,12 +1,29 @@
 package types
 
 import (
+	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
+	"github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 	"testing"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/stretchr/testify/require"
 )
+
+var ValidHostChainInMsg = HostChain{
+	Id:           1,
+	ChainId:      "test-1",
+	ConnectionId: ibcexported.LocalhostConnectionID,
+	IcaAccount:   types.ICAAccount{},
+	Features: Feature{LiquidStakeIBC: LiquidStake{
+		FeatureType:     0,
+		CodeID:          0,
+		Instantiation:   0,
+		ContractAddress: "",
+		Denoms:          []string{},
+		Enabled:         false,
+	}},
+}
 
 func TestMsgUpdateParams_ValidateBasic(t *testing.T) {
 	tests := []struct {
@@ -117,6 +134,7 @@ func TestMsgDeleteHostChain_ValidateBasic(t *testing.T) {
 			name: "valid address",
 			msg: MsgDeleteHostChain{
 				Authority: authtypes.NewModuleAddress("addr1").String(),
+				Id:        1,
 			},
 		},
 	}

--- a/x/ratesync/types/types.go
+++ b/x/ratesync/types/types.go
@@ -30,6 +30,11 @@ func (hc HostChain) ValidateBasic() error {
 		if err != nil {
 			return err
 		}
+		//Make sure it matches default.
+		_, err = IDFromPortID(portID)
+		if err != nil {
+			return err
+		}
 	}
 
 	switch hc.IcaAccount.ChannelState {
@@ -162,7 +167,7 @@ func (lsConfig LiquidStake) Equals(l2 LiquidStake) bool {
 	return true
 }
 
-func MustICAPortIDfromOwner(owner string) string {
+func MustICAPortIDFromOwner(owner string) string {
 	id, err := icatypes.NewControllerPortID(owner)
 	if err != nil {
 		panic(err)
@@ -174,7 +179,7 @@ func MustICAPortIDfromOwner(owner string) string {
 func DefaultPortOwner(id uint64) string {
 	return fmt.Sprintf("%s%v", DefaultPortOwnerPrefix, id)
 }
-func OwnerfromPortID(portID string) (string, error) {
+func OwnerFromPortID(portID string) (string, error) {
 	prefix := fmt.Sprintf("%s", icatypes.ControllerPortPrefix)
 	idStr, found := strings.CutPrefix(portID, prefix)
 	if !found {
@@ -184,7 +189,7 @@ func OwnerfromPortID(portID string) (string, error) {
 	return idStr, nil
 }
 
-func IDfromPortID(portID string) (uint64, error) {
+func IDFromPortID(portID string) (uint64, error) {
 	prefix := fmt.Sprintf("%s%s", icatypes.ControllerPortPrefix, DefaultPortOwnerPrefix)
 	idStr, found := strings.CutPrefix(portID, prefix)
 	if !found {


### PR DESCRIPTION
fixes - ibc routing, it should not error out on ica packets meant for liquidstakeibc, and liquidstakeibc should not cause ratesync to fail.
portID is not fixed per hostchainID, cannot be reused.