### PR TITLE
chore: reorg imports to make linter happy.

### DIFF
--- a/app/encoding.go
+++ b/app/encoding.go
@@ -1,9 +1,9 @@
 package app
 
 import (
-	"github.com/persistenceOne/pstake-native/v2/app/params"
-
 	"github.com/cosmos/cosmos-sdk/std"
+
+	"github.com/persistenceOne/pstake-native/v2/app/params"
 )
 
 // MakeEncodingConfig creates an EncodingConfig for testing

--- a/app/export.go
+++ b/app/export.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
-
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"

--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -6,20 +6,19 @@ import (
 	"os"
 	"testing"
 
-	pstake "github.com/persistenceOne/pstake-native/v2/app"
-
 	dbm "github.com/cometbft/cometbft-db"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/libs/rand"
-	"github.com/persistenceOne/pstake-native/v2/app/helpers"
-	"github.com/stretchr/testify/require"
-
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/store"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 	simcli "github.com/cosmos/cosmos-sdk/x/simulation/client/cli"
+	"github.com/stretchr/testify/require"
+
+	pstake "github.com/persistenceOne/pstake-native/v2/app"
+	"github.com/persistenceOne/pstake-native/v2/app/helpers"
 )
 
 func init() {

--- a/cmd/pstaked/cmd/genaccounts.go
+++ b/cmd/pstaked/cmd/genaccounts.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/spf13/cobra"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -18,6 +16,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	"github.com/spf13/cobra"
 )
 
 const (

--- a/cmd/pstaked/cmd/testnet.go
+++ b/cmd/pstaked/cmd/testnet.go
@@ -15,9 +15,6 @@ import (
 	tmrand "github.com/cometbft/cometbft/libs/rand"
 	"github.com/cometbft/cometbft/types"
 	tmtime "github.com/cometbft/cometbft/types/time"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -36,6 +33,8 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	ibcclienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	ibcchanneltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/persistenceOne/pstake-native/v2/app/params"
 )

--- a/cmd/pstaked/main.go
+++ b/cmd/pstaked/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/server"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 	sdkTypes "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/persistenceOne/pstake-native/v2/app"
 	"github.com/persistenceOne/pstake-native/v2/cmd/pstaked/cmd"
 )

--- a/interchaintest/setup.go
+++ b/interchaintest/setup.go
@@ -5,17 +5,16 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/docker/docker/client"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
-
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	testutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	ibclocalhost "github.com/cosmos/ibc-go/v7/modules/light-clients/09-localhost"
+	"github.com/docker/docker/client"
 	interchaintest "github.com/strangelove-ventures/interchaintest/v7"
 	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v7/ibc"
 	"github.com/strangelove-ventures/interchaintest/v7/testreporter"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 )
 
 var (

--- a/x/liquidstake/client/cli/query.go
+++ b/x/liquidstake/client/cli/query.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/version"
+	"github.com/spf13/cobra"
 
 	"github.com/persistenceOne/pstake-native/v2/x/liquidstake/types"
 )

--- a/x/liquidstake/client/cli/tx.go
+++ b/x/liquidstake/client/cli/tx.go
@@ -9,13 +9,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
+	"github.com/spf13/cobra"
 
 	"github.com/persistenceOne/pstake-native/v2/x/liquidstake/types"
 )

--- a/x/liquidstake/keeper/grpc_query.go
+++ b/x/liquidstake/keeper/grpc_query.go
@@ -3,10 +3,9 @@ package keeper
 import (
 	"context"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/persistenceOne/pstake-native/v2/x/liquidstake/types"
 )

--- a/x/liquidstake/keeper/grpc_query_test.go
+++ b/x/liquidstake/keeper/grpc_query_test.go
@@ -2,11 +2,10 @@ package keeper_test
 
 import (
 	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	_ "github.com/stretchr/testify/suite"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/persistenceOne/pstake-native/v2/x/liquidstake/types"
 )

--- a/x/liquidstake/keeper/keeper_test.go
+++ b/x/liquidstake/keeper/keeper_test.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"cosmossdk.io/math"
-	"github.com/stretchr/testify/suite"
-
 	abci "github.com/cometbft/cometbft/abci/types"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
@@ -17,11 +15,12 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
-	"github.com/cosmos/cosmos-sdk/x/staking"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-
 	"github.com/cosmos/cosmos-sdk/x/mint"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	"github.com/cosmos/cosmos-sdk/x/staking"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/suite"
+
 	chain "github.com/persistenceOne/pstake-native/v2/app"
 	testhelpers "github.com/persistenceOne/pstake-native/v2/app/helpers"
 	"github.com/persistenceOne/pstake-native/v2/x/liquidstake"

--- a/x/liquidstake/keeper/liquidstake.go
+++ b/x/liquidstake/keeper/liquidstake.go
@@ -6,11 +6,11 @@ import (
 
 	"cosmossdk.io/errors"
 	"cosmossdk.io/math"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/persistenceOne/pstake-native/v2/x/liquidstake/types"
 )
 

--- a/x/liquidstake/module.go
+++ b/x/liquidstake/module.go
@@ -6,15 +6,14 @@ import (
 	"fmt"
 
 	abci "github.com/cometbft/cometbft/abci/types"
-	"github.com/gorilla/mux"
-	"github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"github.com/spf13/cobra"
-
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/gorilla/mux"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/spf13/cobra"
 
 	"github.com/persistenceOne/pstake-native/v2/x/liquidstake/client/cli"
 	"github.com/persistenceOne/pstake-native/v2/x/liquidstake/keeper"

--- a/x/liquidstakeibc/keeper/abci_test.go
+++ b/x/liquidstakeibc/keeper/abci_test.go
@@ -1,12 +1,14 @@
 package keeper_test
 
 import (
+	"time"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
 	"github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
-	"time"
 )
 
 func (suite *IntegrationTestSuite) TestKeeper_BeginBlockCode() {

--- a/x/liquidstakeibc/keeper/deposit.go
+++ b/x/liquidstakeibc/keeper/deposit.go
@@ -1,9 +1,9 @@
 package keeper
 
 import (
-	errorsmod "cosmossdk.io/errors"
 	"strconv"
 
+	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/x/liquidstakeibc/keeper/grpc_querier.go
+++ b/x/liquidstakeibc/keeper/grpc_querier.go
@@ -3,12 +3,11 @@ package keeper
 import (
 	"context"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 )

--- a/x/liquidstakeibc/keeper/invariants_test.go
+++ b/x/liquidstakeibc/keeper/invariants_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/keeper"
 )
 

--- a/x/liquidstakeibc/keeper/keeper_test.go
+++ b/x/liquidstakeibc/keeper/keeper_test.go
@@ -9,6 +9,7 @@ import (
 	commitmenttypes "github.com/cosmos/ibc-go/v7/modules/core/23-commitment/types"
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
 	solomachine "github.com/cosmos/ibc-go/v7/modules/light-clients/06-solomachine"
+
 	"github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 )
 

--- a/x/liquidstakeibc/keeper/msg_server_test.go
+++ b/x/liquidstakeibc/keeper/msg_server_test.go
@@ -7,7 +7,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	ibctfrtypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
-
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 
 	"github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/keeper"

--- a/x/liquidstakeibc/keeper/rebalance_test.go
+++ b/x/liquidstakeibc/keeper/rebalance_test.go
@@ -1,12 +1,14 @@
 package keeper_test
 
 import (
+	"testing"
+
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/gogoproto/proto"
+
 	"github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
-	"testing"
 )
 
 func (suite *IntegrationTestSuite) TestKeeper_Rebalance() {

--- a/x/liquidstakeibc/keeper/redelegation.go
+++ b/x/liquidstakeibc/keeper/redelegation.go
@@ -4,6 +4,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
 	"github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 )
 

--- a/x/liquidstakeibc/keeper/redelegation_txs.go
+++ b/x/liquidstakeibc/keeper/redelegation_txs.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 )
 

--- a/x/liquidstakeibc/types/hooks.go
+++ b/x/liquidstakeibc/types/hooks.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/persistenceOne/persistence-sdk/v2/utils"
 )
 

--- a/x/ratesync/genesis.go
+++ b/x/ratesync/genesis.go
@@ -2,6 +2,7 @@ package ratesync
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/persistenceOne/pstake-native/v2/x/ratesync/keeper"
 	"github.com/persistenceOne/pstake-native/v2/x/ratesync/types"
 )

--- a/x/ratesync/genesis_test.go
+++ b/x/ratesync/genesis_test.go
@@ -1,13 +1,13 @@
 package ratesync_test
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/persistenceOne/pstake-native/v2/app/helpers"
-	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
+	"github.com/persistenceOne/pstake-native/v2/app/helpers"
+	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 	"github.com/persistenceOne/pstake-native/v2/x/ratesync"
 	"github.com/persistenceOne/pstake-native/v2/x/ratesync/types"
 )

--- a/x/ratesync/keeper/chain_test.go
+++ b/x/ratesync/keeper/chain_test.go
@@ -1,14 +1,14 @@
 package keeper_test
 
 import (
-	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
-	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 	"strconv"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
+
+	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 	"github.com/persistenceOne/pstake-native/v2/x/ratesync/keeper"
 	"github.com/persistenceOne/pstake-native/v2/x/ratesync/types"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // Prevent strconv unused error

--- a/x/ratesync/keeper/hooks.go
+++ b/x/ratesync/keeper/hooks.go
@@ -5,6 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	epochtypes "github.com/persistenceOne/persistence-sdk/v2/x/epochs/types"
+
 	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 	"github.com/persistenceOne/pstake-native/v2/x/ratesync/types"
 )

--- a/x/ratesync/keeper/ibc.go
+++ b/x/ratesync/keeper/ibc.go
@@ -1,18 +1,19 @@
 package keeper
 
 import (
-	errorsmod "cosmossdk.io/errors"
 	"encoding/json"
 	"fmt"
+	"strconv"
+
+	errorsmod "cosmossdk.io/errors"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	icatypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
-	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
-	"strconv"
 
+	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 	"github.com/persistenceOne/pstake-native/v2/x/ratesync/types"
 )
 

--- a/x/ratesync/keeper/msg_server.go
+++ b/x/ratesync/keeper/msg_server.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
-	"github.com/cosmos/gogoproto/proto"
-	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	"slices"
 
 	errorsmod "cosmossdk.io/errors"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
+	"github.com/cosmos/gogoproto/proto"
+	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 
+	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 	"github.com/persistenceOne/pstake-native/v2/x/ratesync/types"
 )
 

--- a/x/ratesync/keeper/msg_server_test.go
+++ b/x/ratesync/keeper/msg_server_test.go
@@ -2,12 +2,12 @@ package keeper_test
 
 import (
 	"context"
-	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
+	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 	"github.com/persistenceOne/pstake-native/v2/x/ratesync/keeper"
 	"github.com/persistenceOne/pstake-native/v2/x/ratesync/types"
 )

--- a/x/ratesync/keeper/query_test.go
+++ b/x/ratesync/keeper/query_test.go
@@ -1,12 +1,14 @@
 package keeper_test
 
 import (
+	"testing"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	"github.com/persistenceOne/pstake-native/v2/x/ratesync/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"testing"
+
+	"github.com/persistenceOne/pstake-native/v2/x/ratesync/types"
 )
 
 func (suite *IntegrationTestSuite) TestParamsQuery() {

--- a/x/ratesync/keeper/setup_suite_test.go
+++ b/x/ratesync/keeper/setup_suite_test.go
@@ -2,6 +2,9 @@ package keeper_test
 
 import (
 	"fmt"
+	"strconv"
+	"testing"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
@@ -10,13 +13,11 @@ import (
 	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	ibctesting "github.com/cosmos/ibc-go/v7/testing"
-	"github.com/persistenceOne/pstake-native/v2/x/ratesync/types"
 	"github.com/stretchr/testify/suite"
-	"strconv"
-	"testing"
 
 	"github.com/persistenceOne/pstake-native/v2/app"
 	"github.com/persistenceOne/pstake-native/v2/app/helpers"
+	"github.com/persistenceOne/pstake-native/v2/x/ratesync/types"
 )
 
 var (

--- a/x/ratesync/module.go
+++ b/x/ratesync/module.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	// this line is used by starport scaffolding # 1
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cosmos/cosmos-sdk/client"

--- a/x/ratesync/module_simulation.go
+++ b/x/ratesync/module_simulation.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
+
 	ratesyncsimulation "github.com/persistenceOne/pstake-native/v2/x/ratesync/simulation"
 	"github.com/persistenceOne/pstake-native/v2/x/ratesync/types"
 )

--- a/x/ratesync/simulation/msg_update_params.go
+++ b/x/ratesync/simulation/msg_update_params.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+
 	"github.com/persistenceOne/pstake-native/v2/x/ratesync/keeper"
 	"github.com/persistenceOne/pstake-native/v2/x/ratesync/types"
 )

--- a/x/ratesync/types/expected_keepers.go
+++ b/x/ratesync/types/expected_keepers.go
@@ -4,6 +4,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	persistencetypes "github.com/persistenceOne/persistence-sdk/v2/x/epochs/types"
+
 	liquidstaketypes "github.com/persistenceOne/pstake-native/v2/x/liquidstake/types"
 	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 )

--- a/x/ratesync/types/genesis_test.go
+++ b/x/ratesync/types/genesis_test.go
@@ -3,8 +3,9 @@ package types_test
 import (
 	"testing"
 
-	"github.com/persistenceOne/pstake-native/v2/x/ratesync/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/persistenceOne/pstake-native/v2/x/ratesync/types"
 )
 
 func TestGenesisState_Validate(t *testing.T) {

--- a/x/ratesync/types/msgs.go
+++ b/x/ratesync/types/msgs.go
@@ -4,6 +4,7 @@ import (
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
 	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 )
 

--- a/x/ratesync/types/msgs_test.go
+++ b/x/ratesync/types/msgs_test.go
@@ -1,14 +1,15 @@
 package types
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
-	"github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
 	"github.com/stretchr/testify/require"
+
+	"github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 )
 
 var ValidHostChainInMsg = func(id uint64) HostChain {

--- a/x/ratesync/types/types.go
+++ b/x/ratesync/types/types.go
@@ -12,6 +12,7 @@ import (
 	icatypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/types"
 	host "github.com/cosmos/ibc-go/v7/modules/core/24-host"
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
+
 	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 )
 


### PR DESCRIPTION
`gci write -s standard -s default -s "prefix(github.com/persistenceOne/pstake-native)" .`
ignore auto-generated files. 