### PR TITLE
feat: use ibc transfer timeouts instead of block height.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## Unreleased
 
 ### Features
+- [757](https://github.com/persistenceOne/pstake-native/pull/757) Change ibc transfer to use timeoutTimestamp instead of timeoutHeight
 - [755](https://github.com/persistenceOne/pstake-native/pull/755) Add channel-id, port to ratesync host-chains and liquidstake instantiate.
 - [737](https://github.com/persistenceOne/pstake-native/pull/737) Unhandled errors.
 - [736](https://github.com/persistenceOne/pstake-native/pull/736) Check for host denom duplicates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## Unreleased
 
 ### Features
-- [757](https://github.com/persistenceOne/pstake-native/pull/757) Change ibc transfer to use timeoutTimestamp instead of timeoutHeight
-- [755](https://github.com/persistenceOne/pstake-native/pull/755) Add channel-id, port to ratesync host-chains and liquidstake instantiate.
+
+- [757](https://github.com/persistenceOne/pstake-native/pull/757) Change ibc transfer to use timeoutTimestamp instead of
+  timeoutHeight
+- [755](https://github.com/persistenceOne/pstake-native/pull/755) Add channel-id, port to ratesync host-chains and
+  liquidstake instantiate.
 - [737](https://github.com/persistenceOne/pstake-native/pull/737) Unhandled errors.
 - [736](https://github.com/persistenceOne/pstake-native/pull/736) Check for host denom duplicates.
 - [733](https://github.com/persistenceOne/pstake-native/pull/733) Add more validation for host-chain.

--- a/x/liquidstakeibc/keeper/hooks.go
+++ b/x/liquidstakeibc/keeper/hooks.go
@@ -523,7 +523,6 @@ func (k *Keeper) DepositWorkflow(ctx sdk.Context, epoch int64) {
 			continue
 		}
 
-		timeoutHeight := clienttypes.NewHeight(0, 0)
 		timeoutTimestamp := uint64(ctx.BlockTime().UnixNano() + (liquidstakeibctypes.IBCTimeoutTimestamp).Nanoseconds())
 		msg := ibctransfertypes.NewMsgTransfer(
 			ibctransfertypes.PortID,
@@ -531,7 +530,7 @@ func (k *Keeper) DepositWorkflow(ctx sdk.Context, epoch int64) {
 			deposit.Amount,
 			authtypes.NewModuleAddress(liquidstakeibctypes.DepositModuleAccount).String(),
 			hc.DelegationAccount.Address,
-			timeoutHeight,
+			clienttypes.ZeroHeight(),
 			timeoutTimestamp,
 			"",
 		)
@@ -860,7 +859,6 @@ func (k *Keeper) LSMWorkflow(ctx sdk.Context) {
 		totalLSMDepositsSharesAmount := math.LegacyZeroDec()
 		for _, deposit := range k.GetTransferableLSMDeposits(ctx, hc.ChainId) {
 
-			timeoutHeight := clienttypes.NewHeight(0, 0)
 			timeoutTimestamp := uint64(ctx.BlockTime().UnixNano() + (liquidstakeibctypes.IBCTimeoutTimestamp).Nanoseconds())
 
 			// craft the IBC message
@@ -870,7 +868,7 @@ func (k *Keeper) LSMWorkflow(ctx sdk.Context) {
 				sdk.NewCoin(deposit.IbcDenom, deposit.Shares.TruncateInt()),
 				authtypes.NewModuleAddress(liquidstakeibctypes.DepositModuleAccount).String(),
 				hc.DelegationAccount.Address,
-				timeoutHeight,
+				clienttypes.ZeroHeight(),
 				timeoutTimestamp,
 				"",
 			)

--- a/x/liquidstakeibc/keeper/ica.go
+++ b/x/liquidstakeibc/keeper/ica.go
@@ -34,7 +34,7 @@ func (k *Keeper) GenerateAndExecuteICATx(
 		Owner:           ownerID,
 		ConnectionId:    connectionID,
 		PacketData:      icaPacketData,
-		RelativeTimeout: uint64(liquidstakeibctypes.ICATimeoutTimestamp.Nanoseconds()),
+		RelativeTimeout: uint64(liquidstakeibctypes.IBCTimeoutTimestamp.Nanoseconds()),
 	}
 
 	handler := k.msgRouter.Handler(msgSendTx)

--- a/x/liquidstakeibc/keeper/keeper.go
+++ b/x/liquidstakeibc/keeper/keeper.go
@@ -219,7 +219,6 @@ func (k *Keeper) SendICATransfer(
 		)
 	}
 
-	timeoutHeight := clienttypes.NewHeight(0, 0)
 	timeoutTimestamp := uint64(ctx.BlockTime().UnixNano() + (types.IBCTimeoutTimestamp).Nanoseconds())
 
 	// prepare the msg transfer to bring the undelegation back
@@ -229,7 +228,7 @@ func (k *Keeper) SendICATransfer(
 		amount,
 		sender,
 		receiver,
-		timeoutHeight,
+		clienttypes.ZeroHeight(),
 		timeoutTimestamp,
 		"",
 	)

--- a/x/liquidstakeibc/keeper/keeper.go
+++ b/x/liquidstakeibc/keeper/keeper.go
@@ -219,10 +219,8 @@ func (k *Keeper) SendICATransfer(
 		)
 	}
 
-	timeoutHeight := clienttypes.NewHeight(
-		clienttypes.GetSelfHeight(ctx).GetRevisionNumber(),
-		clienttypes.GetSelfHeight(ctx).GetRevisionHeight()+types.IBCTimeoutHeightIncrement,
-	)
+	timeoutHeight := clienttypes.NewHeight(0, 0)
+	timeoutTimestamp := uint64(ctx.BlockTime().UnixNano() + (types.IBCTimeoutTimestamp).Nanoseconds())
 
 	// prepare the msg transfer to bring the undelegation back
 	msgTransfer := ibctransfertypes.NewMsgTransfer(
@@ -232,7 +230,7 @@ func (k *Keeper) SendICATransfer(
 		sender,
 		receiver,
 		timeoutHeight,
-		0,
+		timeoutTimestamp,
 		"",
 	)
 

--- a/x/liquidstakeibc/keeper/setup_suite_test.go
+++ b/x/liquidstakeibc/keeper/setup_suite_test.go
@@ -409,7 +409,7 @@ func (suite *IntegrationTestSuite) TestOneFullFlow() {
 	suite.Require().True(found)
 	suite.Require().Equal(types.Deposit_DEPOSIT_DELEGATING, deposit.State)
 
-	timeoutTimestamp := uint64(suite.chainA.GetContext().BlockTime().UnixNano()) + uint64(types.ICATimeoutTimestamp.Nanoseconds()) - uint64(time.Second*5) // sub one b
+	timeoutTimestamp := uint64(suite.chainA.GetContext().BlockTime().UnixNano()) + uint64(types.IBCTimeoutTimestamp.Nanoseconds()) - uint64(time.Second*5) // sub one b
 	data, err := suite.CreateICAData(deposit.Amount.Amount, hc, 0)
 	suite.NoError(err)
 

--- a/x/liquidstakeibc/types/keys.go
+++ b/x/liquidstakeibc/types/keys.go
@@ -45,9 +45,7 @@ const (
 
 	LiquidStakeDenomPrefix = "stk"
 
-	IBCTimeoutHeightIncrement uint64 = 1000
-
-	ICATimeoutTimestamp = 120 * time.Minute
+	IBCTimeoutTimestamp = 120 * time.Minute
 
 	ICAMessagesChunkSize = 10
 


### PR DESCRIPTION
- pstake ibc transfers use last client update + height, change it to use timeout timestamp