### PR TITLE
fix: make stkxprt staking respect and update global liquid staking cap

### DIFF
--- a/x/liquidstake/keeper/liquidstake.go
+++ b/x/liquidstake/keeper/liquidstake.go
@@ -375,6 +375,12 @@ func (k Keeper) LSMDelegate(
 		return sdk.ZeroDec(), sdk.ZeroInt(), types.ErrTooSmallLiquidStakeAmount
 	}
 
+	// after LSM redemption, accounted liquid shares are ignored,
+	// but we have to still account it because now delegation is owned by a LS protocol
+	if err := k.stakingKeeper.SafelyIncreaseTotalLiquidStakedTokens(ctx, stkXPRTMintAmount, false); err != nil {
+		return sdk.ZeroDec(), sdk.ZeroInt(), types.ErrDelegationFailed.Wrap(err.Error())
+	}
+
 	// mint stkXPRT on module acc
 	mintCoin := sdk.NewCoins(sdk.NewCoin(liquidBondDenom, stkXPRTMintAmount))
 	err = k.bankKeeper.MintCoins(ctx, types.ModuleName, mintCoin)

--- a/x/liquidstake/keeper/rebalancing.go
+++ b/x/liquidstake/keeper/rebalancing.go
@@ -265,8 +265,10 @@ func (k Keeper) AutocompoundStakingRewards(ctx sdk.Context, whitelistedValsMap t
 	if err != nil {
 		logger := k.Logger(ctx)
 		logger.Error("re-staking failed", "error", err)
-		return
+
+		// skip errors as they might occur due to reaching global liquid cap
 	}
+
 	writeCache()
 
 	// move autocompounding fee from the balance to fee account

--- a/x/liquidstake/types/errors.go
+++ b/x/liquidstake/types/errors.go
@@ -24,4 +24,6 @@ var (
 	ErrWhitelistedValidatorsList                    = errors.Register(ModuleName, 19, "whitelisted validators list incorrect")
 	ErrActiveLiquidValidatorsWeightQuorumNotReached = errors.Register(ModuleName, 20, "active liquid validators weight quorum not reached")
 	ErrModulePaused                                 = errors.Register(ModuleName, 21, "module functions have been paused")
+	ErrDelegationFailed                             = errors.Register(ModuleName, 22, "delegation failed")
+	ErrUnbondFailed                                 = errors.Register(ModuleName, 23, "unbond failed")
 )

--- a/x/liquidstake/types/expected_keepers.go
+++ b/x/liquidstake/types/expected_keepers.go
@@ -75,6 +75,8 @@ type StakingKeeper interface {
 	BlockValidatorUpdates(ctx sdk.Context) []abci.ValidatorUpdate
 	HasMaxUnbondingDelegationEntries(ctx sdk.Context,
 		delegatorAddr sdk.AccAddress, validatorAddr sdk.ValAddress) bool
+	SafelyIncreaseTotalLiquidStakedTokens(ctx sdk.Context, amount math.Int, sharesAlreadyBonded bool) error
+	DecreaseTotalLiquidStakedTokens(ctx sdk.Context, amount math.Int) error
 }
 
 // DistrKeeper expected distribution keeper (noalias)


### PR DESCRIPTION
## 1. Overview

Replaced direct calls to stakingKeeper with a wrapper that does updates on global liquid stake accounting and checks the caps.

