### PR TITLE
fix: switch module account of -LiquidStakeProxyAcc to 32-byte module address

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -197,14 +197,15 @@ var (
 		ibctransfertypes.ModuleName:                   {authtypes.Minter, authtypes.Burner},
 		ibcfeetypes.ModuleName:                        nil,
 		liquidstakeibctypes.ModuleName:                {authtypes.Minter, authtypes.Burner},
-		liquidstaketypes.ModuleName:                   {authtypes.Minter, authtypes.Burner},
 		liquidstakeibctypes.DepositModuleAccount:      nil,
 		liquidstakeibctypes.UndelegationModuleAccount: {authtypes.Burner},
+		liquidstaketypes.ModuleName:                   {authtypes.Minter, authtypes.Burner},
 	}
 
 	receiveAllowedMAcc = map[string]bool{
 		liquidstakeibctypes.DepositModuleAccount:      true,
 		liquidstakeibctypes.UndelegationModuleAccount: true,
+		liquidstaketypes.ModuleName:                   true,
 	}
 )
 

--- a/app/app.go
+++ b/app/app.go
@@ -187,26 +187,24 @@ var (
 
 	// module account permissions
 	maccPerms = map[string][]string{
-		authtypes.FeeCollectorName:                           nil,
-		distrtypes.ModuleName:                                nil,
-		icatypes.ModuleName:                                  nil,
-		minttypes.ModuleName:                                 {authtypes.Minter},
-		stakingtypes.BondedPoolName:                          {authtypes.Burner, authtypes.Staking},
-		stakingtypes.NotBondedPoolName:                       {authtypes.Burner, authtypes.Staking},
-		govtypes.ModuleName:                                  {authtypes.Burner},
-		ibctransfertypes.ModuleName:                          {authtypes.Minter, authtypes.Burner},
-		ibcfeetypes.ModuleName:                               nil,
-		liquidstakeibctypes.ModuleName:                       {authtypes.Minter, authtypes.Burner},
-		liquidstaketypes.ModuleName:                          {authtypes.Minter, authtypes.Burner},
-		liquidstaketypes.ModuleName + "-LiquidStakeProxyAcc": {authtypes.Staking},
-		liquidstakeibctypes.DepositModuleAccount:             nil,
-		liquidstakeibctypes.UndelegationModuleAccount:        {authtypes.Burner},
+		authtypes.FeeCollectorName:                    nil,
+		distrtypes.ModuleName:                         nil,
+		icatypes.ModuleName:                           nil,
+		minttypes.ModuleName:                          {authtypes.Minter},
+		stakingtypes.BondedPoolName:                   {authtypes.Burner, authtypes.Staking},
+		stakingtypes.NotBondedPoolName:                {authtypes.Burner, authtypes.Staking},
+		govtypes.ModuleName:                           {authtypes.Burner},
+		ibctransfertypes.ModuleName:                   {authtypes.Minter, authtypes.Burner},
+		ibcfeetypes.ModuleName:                        nil,
+		liquidstakeibctypes.ModuleName:                {authtypes.Minter, authtypes.Burner},
+		liquidstaketypes.ModuleName:                   {authtypes.Minter, authtypes.Burner},
+		liquidstakeibctypes.DepositModuleAccount:      nil,
+		liquidstakeibctypes.UndelegationModuleAccount: {authtypes.Burner},
 	}
 
 	receiveAllowedMAcc = map[string]bool{
-		liquidstakeibctypes.DepositModuleAccount:             true,
-		liquidstakeibctypes.UndelegationModuleAccount:        true,
-		liquidstaketypes.ModuleName + "-LiquidStakeProxyAcc": true,
+		liquidstakeibctypes.DepositModuleAccount:      true,
+		liquidstakeibctypes.UndelegationModuleAccount: true,
 	}
 )
 

--- a/x/liquidstake/keeper/liquidstake.go
+++ b/x/liquidstake/keeper/liquidstake.go
@@ -375,12 +375,6 @@ func (k Keeper) LSMDelegate(
 		return sdk.ZeroDec(), sdk.ZeroInt(), types.ErrTooSmallLiquidStakeAmount
 	}
 
-	// after LSM redemption, accounted liquid shares are ignored,
-	// but we have to still account it because now delegation is owned by a LS protocol
-	if err := k.stakingKeeper.SafelyIncreaseTotalLiquidStakedTokens(ctx, stkXPRTMintAmount, false); err != nil {
-		return sdk.ZeroDec(), sdk.ZeroInt(), types.ErrDelegationFailed.Wrap(err.Error())
-	}
-
 	// mint stkXPRT on module acc
 	mintCoin := sdk.NewCoins(sdk.NewCoin(liquidBondDenom, stkXPRTMintAmount))
 	err = k.bankKeeper.MintCoins(ctx, types.ModuleName, mintCoin)

--- a/x/liquidstake/types/params.go
+++ b/x/liquidstake/types/params.go
@@ -7,7 +7,7 @@ import (
 
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/types/address"
 )
 
 // Parameter store keys
@@ -39,10 +39,15 @@ var (
 	AutocompoundTrigger = math.LegacyNewDecWithPrec(1, 3) // "0.001000000000000000"
 
 	// LiquidStakeProxyAcc is a proxy reserve account for delegation and undelegation.
-	LiquidStakeProxyAcc = authtypes.NewModuleAddress(ModuleName + "-LiquidStakeProxyAcc")
+	//
+	// Important: derive this address using module.Address to obtain a 32-byte version distinguishable for LSM
+	// authtypes.NewModuleAddress returns 20-byte addresses.
+	LiquidStakeProxyAcc = sdk.AccAddress(address.Module(ModuleName, []byte("-LiquidStakeProxyAcc")))
 
 	// DummyFeeAccountAcc is a dummy fee collection account that should be replaced via params.
-	DummyFeeAccountAcc = authtypes.NewModuleAddress(ModuleName + "-FeeAcc")
+	//
+	// Note: it could be authtypes.NewModuleAddress, but made it derived as well, for consistency.
+	DummyFeeAccountAcc = sdk.AccAddress(address.Module(ModuleName, []byte("-FeeAcc")))
 )
 
 // DefaultParams returns the default liquidstake module parameters.


### PR DESCRIPTION
This allows it to be detectable in LSM implementation as module account, thus applying liquid staking caps accordingly. During LSM redemption on behalf of the liquidstaking module account as delegator, the global liquid stake counter is not reduced.
