### PR TITLE
refactor: use msgserver delegate instead of delegate

### DIFF
--- a/x/liquidstake/keeper/keeper_test.go
+++ b/x/liquidstake/keeper/keeper_test.go
@@ -107,7 +107,7 @@ func (s *KeeperTestSuite) liquidStaking(liquidStaker sdk.AccAddress, stakingAmt 
 		ctx, liquidStaker, params.LiquidBondDenom,
 	).Amount
 
-	newShares, stkXPRTMintAmt, err := s.keeper.LiquidStake(
+	stkXPRTMintAmt, err := s.keeper.LiquidStake(
 		ctx,
 		types.LiquidStakeProxyAcc,
 		liquidStaker,
@@ -122,7 +122,6 @@ func (s *KeeperTestSuite) liquidStaking(liquidStaker sdk.AccAddress, stakingAmt 
 	).Amount
 
 	s.Require().NoError(err)
-	s.NotEqualValues(newShares, sdk.ZeroDec())
 	s.Require().EqualValues(
 		stkXPRTMintAmt, stkxprtBalanceAfter.Sub(stkxprtBalanceBefore),
 	)

--- a/x/liquidstake/keeper/liquidstake_test.go
+++ b/x/liquidstake/keeper/liquidstake_test.go
@@ -24,12 +24,11 @@ func (s *KeeperTestSuite) TestLiquidStake() {
 
 	// fail, no active validator
 	cachedCtx, _ := s.ctx.CacheContext()
-	newShares, stkXPRTMintAmt, err := s.keeper.LiquidStake(
+	stkXPRTMintAmt, err := s.keeper.LiquidStake(
 		cachedCtx, types.LiquidStakeProxyAcc, s.delAddrs[0],
 		sdk.NewCoin(sdk.DefaultBondDenom, stakingAmt),
 	)
 	s.Require().ErrorIs(err, types.ErrActiveLiquidValidatorsNotExists)
-	s.Require().Equal(newShares, sdk.ZeroDec())
 	s.Require().Equal(stkXPRTMintAmt, sdk.ZeroInt())
 
 	// add active validator
@@ -67,12 +66,11 @@ func (s *KeeperTestSuite) TestLiquidStake() {
 	s.Require().Equal(sdk.ZeroInt(), res[2].LiquidTokens)
 
 	// liquid stake
-	newShares, stkXPRTMintAmt, err = s.keeper.LiquidStake(
+	stkXPRTMintAmt, err = s.keeper.LiquidStake(
 		s.ctx, types.LiquidStakeProxyAcc, s.delAddrs[0],
 		sdk.NewCoin(sdk.DefaultBondDenom, stakingAmt),
 	)
 	s.Require().NoError(err)
-	s.Require().Equal(newShares, stakingAmt.ToLegacyDec())
 	s.Require().Equal(stkXPRTMintAmt, stakingAmt)
 
 	_, found := s.app.StakingKeeper.GetDelegation(
@@ -310,7 +308,7 @@ func (s *KeeperTestSuite) TestLiquidStakeEdgeCases() {
 	s.keeper.UpdateLiquidValidatorSet(s.ctx)
 
 	// fail Invalid BondDenom case
-	_, _, err := s.keeper.LiquidStake(s.ctx, types.LiquidStakeProxyAcc, s.delAddrs[0], sdk.NewCoin("bad", stakingAmt))
+	_, err := s.keeper.LiquidStake(s.ctx, types.LiquidStakeProxyAcc, s.delAddrs[0], sdk.NewCoin("bad", stakingAmt))
 	s.Require().ErrorIs(err, types.ErrInvalidBondDenom)
 
 	// liquid stake, unstaking with huge amount
@@ -423,13 +421,13 @@ func (s *KeeperTestSuite) TestShareInflation() {
 	protocol := s.delAddrs[3]
 
 	// 0. [a solution?] be first depositor
-	_, mintAmount0, err := s.keeper.LiquidStake(s.ctx, types.LiquidStakeProxyAcc,
+	mintAmount0, err := s.keeper.LiquidStake(s.ctx, types.LiquidStakeProxyAcc,
 		protocol, sdk.NewCoin(sdk.DefaultBondDenom, initializingStakingAmt))
 	s.Require().NoError(err)
 	s.Require().Equal(mintAmount0, initializingStakingAmt)
 
 	// 1. attacker becomes first depositor and liquid stake
-	_, mintAmount, err := s.keeper.LiquidStake(s.ctx, types.LiquidStakeProxyAcc,
+	mintAmount, err := s.keeper.LiquidStake(s.ctx, types.LiquidStakeProxyAcc,
 		attacker, sdk.NewCoin(sdk.DefaultBondDenom, initialStakingAmt))
 	s.Require().NoError(err)
 	s.Require().Equal(mintAmount, initialStakingAmt)
@@ -446,7 +444,7 @@ func (s *KeeperTestSuite) TestShareInflation() {
 
 	// 4. user tx went through but receives fewer shares than intended
 	// stkXPRT to mint = 1 * 1000 / (1+500) = 1.99 = 1
-	_, mintAmount, err = s.keeper.LiquidStake(s.ctx, types.LiquidStakeProxyAcc, user, sdk.NewCoin(sdk.DefaultBondDenom, userStakeAmount))
+	mintAmount, err = s.keeper.LiquidStake(s.ctx, types.LiquidStakeProxyAcc, user, sdk.NewCoin(sdk.DefaultBondDenom, userStakeAmount))
 	s.Require().NoError(err)
 	s.Require().Equal(mintAmount, math.NewInt(952))
 

--- a/x/liquidstake/keeper/msg_server.go
+++ b/x/liquidstake/keeper/msg_server.go
@@ -35,7 +35,7 @@ var _ types.MsgServer = msgServer{}
 func (k msgServer) LiquidStake(goCtx context.Context, msg *types.MsgLiquidStake) (*types.MsgLiquidStakeResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	newShares, stkXPRTMintAmount, err := k.Keeper.LiquidStake(ctx, types.LiquidStakeProxyAcc, msg.GetDelegator(), msg.Amount)
+	stkXPRTMintAmount, err := k.Keeper.LiquidStake(ctx, types.LiquidStakeProxyAcc, msg.GetDelegator(), msg.Amount)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,6 @@ func (k msgServer) LiquidStake(goCtx context.Context, msg *types.MsgLiquidStake)
 			types.EventTypeMsgLiquidStake,
 			sdk.NewAttribute(types.AttributeKeyDelegator, msg.DelegatorAddress),
 			sdk.NewAttribute(types.AttributeKeyLiquidAmount, msg.Amount.String()),
-			sdk.NewAttribute(types.AttributeKeyNewShares, newShares.String()),
 			sdk.NewAttribute(types.AttributeKeyStkXPRTMintedAmount, sdk.Coin{Denom: liquidBondDenom, Amount: stkXPRTMintAmount}.String()),
 			sdk.NewAttribute(types.AttributeKeyCValue, cValue.String()),
 		),
@@ -104,7 +103,7 @@ func (k msgServer) StakeToLP(goCtx context.Context, msg *types.MsgStakeToLP) (*t
 	})
 
 	if (msg.LiquidAmount != sdk.Coin{}) && (msg.LiquidAmount.Amount != math.Int{}) && msg.LiquidAmount.Amount.IsPositive() {
-		newShares, stkXPRTMintAmount, err := k.Keeper.LiquidStake(ctx, types.LiquidStakeProxyAcc, msg.GetDelegator(), msg.LiquidAmount)
+		stkXPRTMintAmount, err := k.Keeper.LiquidStake(ctx, types.LiquidStakeProxyAcc, msg.GetDelegator(), msg.LiquidAmount)
 		if err != nil {
 			return nil, err
 		}
@@ -128,7 +127,6 @@ func (k msgServer) StakeToLP(goCtx context.Context, msg *types.MsgStakeToLP) (*t
 				types.EventTypeMsgStakeToLP,
 				sdk.NewAttribute(types.AttributeKeyDelegator, msg.DelegatorAddress),
 				sdk.NewAttribute(types.AttributeKeyLiquidAmount, msg.LiquidAmount.String()),
-				sdk.NewAttribute(types.AttributeKeyNewShares, newShares.String()),
 				sdk.NewAttribute(types.AttributeKeyStkXPRTMintedAmount, stkXPRTMinted.String()),
 				sdk.NewAttribute(types.AttributeKeyCValue, cValue.String()),
 			),

--- a/x/liquidstake/keeper/rebalancing_test.go
+++ b/x/liquidstake/keeper/rebalancing_test.go
@@ -33,9 +33,8 @@ func (s *KeeperTestSuite) TestRebalancingCase1() {
 	reds := s.keeper.UpdateLiquidValidatorSet(s.ctx)
 	s.Require().Len(reds, 0)
 
-	newShares, stkXPRTMintAmt, err := s.keeper.LiquidStake(s.ctx, types.LiquidStakeProxyAcc, s.delAddrs[0], sdk.NewCoin(sdk.DefaultBondDenom, stakingAmt))
+	stkXPRTMintAmt, err := s.keeper.LiquidStake(s.ctx, types.LiquidStakeProxyAcc, s.delAddrs[0], sdk.NewCoin(sdk.DefaultBondDenom, stakingAmt))
 	s.Require().NoError(err)
-	s.Require().Equal(newShares, stakingAmt.ToLegacyDec())
 	s.Require().Equal(stkXPRTMintAmt, stakingAmt)
 	reds = s.keeper.UpdateLiquidValidatorSet(s.ctx)
 	s.Require().Len(reds, 0)
@@ -306,9 +305,8 @@ func (s *KeeperTestSuite) TestRebalancingConsecutiveCase() {
 	reds := s.keeper.UpdateLiquidValidatorSet(s.ctx)
 	s.Require().Len(reds, 0)
 
-	newShares, stkXPRTMintAmt, err := s.keeper.LiquidStake(s.ctx, types.LiquidStakeProxyAcc, s.delAddrs[0], sdk.NewCoin(sdk.DefaultBondDenom, stakingAmt))
+	stkXPRTMintAmt, err := s.keeper.LiquidStake(s.ctx, types.LiquidStakeProxyAcc, s.delAddrs[0], sdk.NewCoin(sdk.DefaultBondDenom, stakingAmt))
 	s.Require().NoError(err)
-	s.Require().Equal(newShares, stakingAmt.ToLegacyDec())
 	s.Require().Equal(stkXPRTMintAmt, stakingAmt)
 	// assert rebalanced
 	reds = s.keeper.UpdateLiquidValidatorSet(s.ctx)
@@ -450,7 +448,7 @@ func (s *KeeperTestSuite) TestRebalancingConsecutiveCase() {
 	s.printRedelegationsLiquidTokens()
 
 	// additional liquid stake when not rebalanced
-	_, _, err = s.keeper.LiquidStake(s.ctx, types.LiquidStakeProxyAcc, s.delAddrs[0], sdk.NewCoin(sdk.DefaultBondDenom, math.NewInt(1000000000)))
+	_, err = s.keeper.LiquidStake(s.ctx, types.LiquidStakeProxyAcc, s.delAddrs[0], sdk.NewCoin(sdk.DefaultBondDenom, math.NewInt(1000000000)))
 	s.Require().NoError(err)
 	s.printRedelegationsLiquidTokens()
 

--- a/x/liquidstake/types/errors.go
+++ b/x/liquidstake/types/errors.go
@@ -26,4 +26,5 @@ var (
 	ErrModulePaused                                 = errors.Register(ModuleName, 21, "module functions have been paused")
 	ErrDelegationFailed                             = errors.Register(ModuleName, 22, "delegation failed")
 	ErrUnbondFailed                                 = errors.Register(ModuleName, 23, "unbond failed")
+	ErrInvalidResponse                              = errors.Register(ModuleName, 24, "invalid response")
 )

--- a/x/liquidstake/types/liquidstake_test.go
+++ b/x/liquidstake/types/liquidstake_test.go
@@ -316,9 +316,8 @@ func (s *KeeperTestSuite) TestLiquidStake() {
 
 	// fail, no active validator
 	cachedCtx, _ := s.ctx.CacheContext()
-	newShares, stkXPRTMintAmt, err := s.keeper.LiquidStake(cachedCtx, types.LiquidStakeProxyAcc, s.delAddrs[0], sdk.NewCoin(sdk.DefaultBondDenom, stakingAmt))
+	stkXPRTMintAmt, err := s.keeper.LiquidStake(cachedCtx, types.LiquidStakeProxyAcc, s.delAddrs[0], sdk.NewCoin(sdk.DefaultBondDenom, stakingAmt))
 	s.Require().ErrorIs(err, types.ErrActiveLiquidValidatorsNotExists)
-	s.Require().Equal(newShares, sdk.ZeroDec())
 	s.Require().Equal(stkXPRTMintAmt, sdk.ZeroInt())
 
 	// add active validator
@@ -350,9 +349,8 @@ func (s *KeeperTestSuite) TestLiquidStake() {
 	s.Require().Equal(sdk.ZeroInt(), res[2].LiquidTokens)
 
 	// liquid stake
-	newShares, stkXPRTMintAmt, err = s.keeper.LiquidStake(s.ctx, types.LiquidStakeProxyAcc, s.delAddrs[0], sdk.NewCoin(sdk.DefaultBondDenom, stakingAmt))
+	stkXPRTMintAmt, err = s.keeper.LiquidStake(s.ctx, types.LiquidStakeProxyAcc, s.delAddrs[0], sdk.NewCoin(sdk.DefaultBondDenom, stakingAmt))
 	s.Require().NoError(err)
-	s.Require().Equal(newShares, stakingAmt.ToLegacyDec())
 	s.Require().Equal(stkXPRTMintAmt, stakingAmt)
 
 	_, found := s.app.StakingKeeper.GetDelegation(s.ctx, s.delAddrs[0], valOpers[0])


### PR DESCRIPTION
removes newshares from events of liquidstake, it should be present in events of each individual staking tx, can be summed if required for analysis usecases
