### PR TITLE
fix: use getChain from Host denom as rewards account too does MsgTransfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+### Features
+
+### Improvements
+
+### Bug Fixes
+
+- [792](https://github.com/persistenceOne/pstake-native/pull/792) Use GetHostChainFromHostDenom in ICA Transfer
+  unsuccessfulAck instead of GetHostChainFromDelegatorAddress as Rewards account too uses ICA Transfer to autocompound
+
 ## [v2.11.0] - 2024-03-12
 
 ### Features
@@ -46,7 +55,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 - [773](https://github.com/persistenceOne/pstake-native/pull/773) Improve logging.
- 
+
 ### Bug Fixes
 
 - [774](https://github.com/persistenceOne/pstake-native/pull/774) Fix liquidstake params test.

--- a/x/liquidstakeibc/keeper/ibc.go
+++ b/x/liquidstakeibc/keeper/ibc.go
@@ -406,7 +406,7 @@ func (k *Keeper) handleUnsuccessfulAck(
 			}
 
 			// get the host chain using the delegator address
-			hc, found := k.GetHostChainFromDelegatorAddress(ctx, parsedMsg.Sender)
+			hc, found := k.GetHostChainFromHostDenom(ctx, parsedMsg.Token.Denom)
 			if !found {
 				k.Logger(ctx).Error(
 					"could not find host chain from ica delegator address",


### PR DESCRIPTION
It saves us from an unnecessary error log since rewards account too does ICA Transfer to autocompound and it can fail/ timeout.