### PR TITLE
chore: Modify error logs acording to x/liquidstakeibc module

### DIFF
--- a/x/liquidstake/keeper/liquidstake.go
+++ b/x/liquidstake/keeper/liquidstake.go
@@ -226,7 +226,6 @@ func (k Keeper) DelegateWithCap(
 	}
 	res, err := handler(ctx, msgDelegate)
 	if err != nil {
-		k.Logger(ctx).Error("failed to execute delegate msg,", "msg", msgDelegate.String(), "err", err)
 		return errorsmod.Wrapf(types.ErrDelegationFailed, "failed to send delegate msg with err: %v", err)
 	}
 	ctx.EventManager().EmitEvents(res.GetEvents())
@@ -807,18 +806,17 @@ func (k Keeper) WithdrawLiquidRewards(ctx sdk.Context, proxyAcc sdk.AccAddress) 
 			// run the message handler
 			handler := k.router.Handler(msgWithdraw)
 			if handler == nil {
-				k.Logger(ctx).Error(
-					"unrecognized message route",
-					"msgRoute", sdk.MsgTypeURL(msgWithdraw),
-				)
+				k.Logger(ctx).Error("could not find distribution handler for withdraw rewards msg")
 				return true
 			}
 			res, err := handler(ctx, msgWithdraw)
 			if err != nil {
 				k.Logger(ctx).Error(
 					"failed to execute withdraw rewards msg",
-					"msg", msgWithdraw.String(),
-					"err", err,
+					types.MsgKeyVal,
+					msgWithdraw.String(),
+					types.ErrorKeyVal,
+					err,
 				)
 				// no need to return here, will be picked up in the next epoch
 			} else {

--- a/x/liquidstake/keeper/liquidstake.go
+++ b/x/liquidstake/keeper/liquidstake.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"encoding/json"
-	"fmt"
 	"sort"
 	"time"
 
@@ -561,7 +560,7 @@ func (k Keeper) LiquidDelegate(ctx sdk.Context, proxyAcc sdk.AccAddress, activeV
 		validator, _ := k.stakingKeeper.GetValidator(ctx, val.GetOperator())
 		err = k.DelegateWithCap(ctx, proxyAcc, validator, weightedAmt[i])
 		if err != nil {
-			return fmt.Errorf("failed to delegate to validator %s: %w", val.GetOperator(), err)
+			return errorsmod.Wrapf(err, "failed to delegate to validator %s", val.GetOperator())
 		}
 	}
 	return nil

--- a/x/liquidstake/keeper/liquidstake.go
+++ b/x/liquidstake/keeper/liquidstake.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"encoding/json"
+	"fmt"
 	"sort"
 	"time"
 
@@ -560,7 +561,7 @@ func (k Keeper) LiquidDelegate(ctx sdk.Context, proxyAcc sdk.AccAddress, activeV
 		validator, _ := k.stakingKeeper.GetValidator(ctx, val.GetOperator())
 		err = k.DelegateWithCap(ctx, proxyAcc, validator, weightedAmt[i])
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to delegate to validator %s: %w", val.GetOperator(), err)
 		}
 	}
 	return nil

--- a/x/liquidstake/keeper/liquidstake.go
+++ b/x/liquidstake/keeper/liquidstake.go
@@ -222,10 +222,22 @@ func (k Keeper) DelegateWithCap(
 	}
 	handler := k.router.Handler(msgDelegate)
 	if handler == nil {
-		return sdkerrors.ErrUnknownRequest.Wrapf("unrecognized message route: %s", sdk.MsgTypeURL(msgDelegate))
+		return errorsmod.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized message route: %s", sdk.MsgTypeURL(msgDelegate))
 	}
 	res, err := handler(ctx, msgDelegate)
 	if err != nil {
+		k.Logger(ctx).Error(
+			"failed to send delegate msg",
+			types.ErrorKeyVal,
+			err,
+			types.DelegatorKeyVal,
+			delegatorAddress.String(),
+			types.ValidatorKeyVal,
+			validator.OperatorAddress,
+			types.AmountKeyVal,
+			bondAmt.String(),
+		)
+
 		return errorsmod.Wrapf(types.ErrDelegationFailed, "failed to send delegate msg with err: %v", err)
 	}
 	ctx.EventManager().EmitEvents(res.GetEvents())

--- a/x/liquidstake/keeper/rebalancing.go
+++ b/x/liquidstake/keeper/rebalancing.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 
@@ -32,7 +33,7 @@ func (k Keeper) TryRedelegation(ctx sdk.Context, re types.Redelegation) (complet
 		ctx, re.Delegator, srcVal, re.Amount,
 	)
 	if err != nil {
-		return time.Time{}, err
+		return time.Time{}, fmt.Errorf("failed to validate unbond amount: %w", err)
 	}
 
 	// when last, full redelegation of shares from delegation
@@ -42,7 +43,7 @@ func (k Keeper) TryRedelegation(ctx sdk.Context, re types.Redelegation) (complet
 	cachedCtx, writeCache := ctx.CacheContext()
 	completionTime, err = k.stakingKeeper.BeginRedelegation(cachedCtx, re.Delegator, srcVal, dstVal, shares)
 	if err != nil {
-		return time.Time{}, err
+		return time.Time{}, fmt.Errorf("failed to begin redelegation: %w", err)
 	}
 	writeCache()
 	return completionTime, nil

--- a/x/liquidstake/types/logging.go
+++ b/x/liquidstake/types/logging.go
@@ -1,0 +1,11 @@
+package types
+
+const (
+	// keyvals
+	DelegatorKeyVal    string = "delegator"
+	SrcValidatorKeyVal string = "src_validator"
+	DstValidatorKeyVal string = "dst_validator"
+	AmountKeyVal       string = "amount"
+	MsgKeyVal          string = "msg"
+	ErrorKeyVal        string = "error"
+)

--- a/x/liquidstake/types/logging.go
+++ b/x/liquidstake/types/logging.go
@@ -3,6 +3,7 @@ package types
 const (
 	// keyvals
 	DelegatorKeyVal    string = "delegator"
+	ValidatorKeyVal    string = "validator"
 	SrcValidatorKeyVal string = "src_validator"
 	DstValidatorKeyVal string = "dst_validator"
 	AmountKeyVal       string = "amount"

--- a/x/liquidstake/types/logging.go
+++ b/x/liquidstake/types/logging.go
@@ -2,11 +2,18 @@ package types
 
 const (
 	// keyvals
-	DelegatorKeyVal    string = "delegator"
-	ValidatorKeyVal    string = "validator"
-	SrcValidatorKeyVal string = "src_validator"
-	DstValidatorKeyVal string = "dst_validator"
-	AmountKeyVal       string = "amount"
-	MsgKeyVal          string = "msg"
-	ErrorKeyVal        string = "error"
+	DelegatorKeyVal                string = "delegator"
+	ValidatorKeyVal                string = "validator"
+	SrcValidatorKeyVal             string = "src_validator"
+	DstValidatorKeyVal             string = "dst_validator"
+	AmountKeyVal                   string = "amount"
+	MsgKeyVal                      string = "msg"
+	ErrorKeyVal                    string = "error"
+	ActiveWeightQuorumKeyVal       string = "active_weight_quorum"
+	MinActiveWeightQuorumKeyVal    string = "min_active_weight_quorum"
+	ActiveValidatorsKeyVal         string = "active_validators"
+	WhitelistedValidatorsMapKeyVal string = "whitelisted_validators_map"
+	ValidatorsKeyVal               string = "validators"
+	NetAmountStateKeyVal           string = "net_amount_state"
+	TotalLiquidTokensKeyVal        string = "total_liquid_tokens"
 )


### PR DESCRIPTION
## 1. Overview

This PR only tries to clean `x/liquidstake` module loggings, so there's no changes to the consensus.

## 2. Implementation details

- Added some `const`s for log key-values in the `types` directory.
- Better messages for error logs

## 3. How to test/use

Doesn't need any testing

## 4. Checklist

- [ ] Investigate to see if we benefit adding more loggings to this module.
- [ ] Does the Readme need to be updated?