### PR TITLE
fix: protobuf syntax error

### DIFF
--- a/proto/pstake/liquidstake/v1beta1/liquidstake.proto
+++ b/proto/pstake/liquidstake/v1beta1/liquidstake.proto
@@ -96,7 +96,6 @@ message WhitelistedValidator {
   // validator
   string validator_address = 1
       [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
-  ;
 
   // target_weight specifies the target weight for liquid staking, unstaking
   // amount, which is a value for calculating the real weight to be derived


### PR DESCRIPTION
I found and fixed a syntax error in one of the protobuf files—there was an extraneous semicolon on a line by itself.
